### PR TITLE
Thermocouples

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -102,8 +102,7 @@
 									<listOptionValue builtIn="false" value="SDK_OS_FREE_RTOS"/>
 									<listOptionValue builtIn="false" value="SERIAL_PORT_TYPE_UART=1"/>
 									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=0"/>
-									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
-									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=1"/>
 									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
 									<listOptionValue builtIn="false" value="__USE_CMSIS"/>
 									<listOptionValue builtIn="false" value="DEBUG"/>
@@ -111,6 +110,17 @@
 								</option>
 								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.1472448836" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1616961349" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
@@ -122,17 +132,6 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
@@ -195,6 +194,17 @@
 								<option id="com.crt.advproject.gas.arch.779270694" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm4" valueType="enumerated"/>
 								<option id="gnu.both.asm.option.flags.crt.1363850050" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.1048725615" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
@@ -206,17 +216,6 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
@@ -284,12 +283,12 @@
 							</tool>
 							<tool id="com.crt.advproject.link.exe.debug.1808674003" name="MCU Linker" superClass="com.crt.advproject.link.exe.debug">
 								<option id="com.crt.advproject.link.thumb.814290186" name="Thumb mode" superClass="com.crt.advproject.link.thumb" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.memory.load.image.1128562733" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image" value="" valueType="string"/>
-								<option defaultValue="com.crt.advproject.heapAndStack.mcuXpressoStyle" id="com.crt.advproject.link.memory.heapAndStack.style.599827557" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.memory.load.image.1128562733" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image" useByScannerDiscovery="false" value="" valueType="string"/>
+								<option defaultValue="com.crt.advproject.heapAndStack.mcuXpressoStyle" id="com.crt.advproject.link.memory.heapAndStack.style.599827557" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style" useByScannerDiscovery="false" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.memory.heapAndStack.1972476839" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack" value="&amp;Heap:Default;Post Data;Default&amp;Stack:Default;End;Default" valueType="string"/>
-								<option id="com.crt.advproject.link.memory.data.1602209396" name="Global data placement" superClass="com.crt.advproject.link.memory.data" value="" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.1935376594" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections" valueType="stringList"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.gcc.multicore.master.userobjs.1242150886" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.gcc.multicore.master.userobjs" valueType="userObjs"/>
+								<option id="com.crt.advproject.link.memory.data.1602209396" name="Global data placement" superClass="com.crt.advproject.link.memory.data" useByScannerDiscovery="false" value="" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.1935376594" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections" useByScannerDiscovery="false" valueType="stringList"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.gcc.multicore.master.userobjs.1242150886" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.gcc.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.arch.1777470155" name="Architecture" superClass="com.crt.advproject.link.arch" value="com.crt.advproject.link.target.cm4" valueType="enumerated"/>
 								<option id="gnu.c.link.option.nostart.142017723" name="Do not use standard start files (-nostartfiles)" superClass="gnu.c.link.option.nostart"/>
 								<option id="gnu.c.link.option.nodeflibs.1355502826" name="Do not use default libraries (-nodefaultlibs)" superClass="gnu.c.link.option.nodeflibs"/>
@@ -358,8 +357,8 @@
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
-						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry excluding="freertos_kernel/portable/MemMang/heap_1.c|freertos_kernel/portable/MemMang/heap_2.c|freertos_kernel/portable/MemMang/heap_3.c|freertos_kernel/portable/MemMang/heap_5.c|freertos_kernel/portable/MemMang/heap_useNewlib.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="freertos"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
@@ -476,6 +475,17 @@
 								</option>
 								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.551007114" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1188034603" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
@@ -487,17 +497,6 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
@@ -558,6 +557,17 @@
 								<option id="com.crt.advproject.gas.arch.1708340023" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm4" valueType="enumerated"/>
 								<option id="gnu.both.asm.option.flags.crt.728572039" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.1267503675" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
@@ -569,17 +579,6 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers/freertos}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
@@ -719,8 +718,8 @@
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
-						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry excluding="freertos_kernel/portable/MemMang/heap_1.c|freertos_kernel/portable/MemMang/heap_2.c|freertos_kernel/portable/MemMang/heap_3.c|freertos_kernel/portable/MemMang/heap_5.c|freertos_kernel/portable/MemMang/heap_useNewlib.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="freertos"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
@@ -752,7 +751,7 @@
 	<storageModule moduleId="com.nxp.mcuxpresso.core.datamodels">
 		<sdkName>SDK_2.x_MK66FX1M0xxx18</sdkName>
 		<sdkVersion>2.8.2</sdkVersion>
-		<sdkComponents>middleware.freertos-kernel.extension.MK66F18;middleware.freertos-kernel.template.MK66F18;middleware.freertos-kernel.MK66F18;platform.drivers.clock.MK66F18;platform.drivers.common.MK66F18;platform.drivers.gpio.MK66F18;platform.drivers.uart.MK66F18;component.uart_adapter.MK66F18;component.serial_manager_uart.MK66F18;utility.debug_console.MK66F18;component.serial_manager.MK66F18;component.lists.MK66F18;device.MK66F18_startup.MK66F18;platform.Include_common.MK66F18;platform.Include_core_cm4.MK66F18;platform.Include_dsp.MK66F18;device.MK66F18_CMSIS.MK66F18;platform.drivers.dspi_freertos.MK66F18;platform.drivers.dspi.MK66F18;platform.drivers.port.MK66F18;</sdkComponents>
+		<sdkComponents>middleware.freertos-kernel.extension.MK66F18;middleware.freertos-kernel.template.MK66F18;middleware.freertos-kernel.MK66F18;platform.drivers.clock.MK66F18;platform.drivers.common.MK66F18;platform.drivers.gpio.MK66F18;platform.drivers.uart.MK66F18;component.uart_adapter.MK66F18;component.serial_manager_uart.MK66F18;utility.debug_console.MK66F18;component.serial_manager.MK66F18;component.lists.MK66F18;device.MK66F18_startup.MK66F18;platform.Include_common.MK66F18;platform.Include_core_cm4.MK66F18;platform.Include_dsp.MK66F18;device.MK66F18_CMSIS.MK66F18;platform.drivers.dspi_freertos.MK66F18;platform.drivers.dspi.MK66F18;platform.drivers.port.MK66F18;platform.drivers.adc16.MK66F18;platform.drivers.i2c_freertos.MK66F18;platform.drivers.i2c.MK66F18;</sdkComponents>
 		<package>MK66FX1M0VLQ18</package>
 		<core>cm4</core>
 		<coreId>core0_MK66FX1M0xxx18</coreId>

--- a/WB-DAQ-Firmware.mex
+++ b/WB-DAQ-Firmware.mex
@@ -78,8 +78,20 @@
                         <pin_feature name="gpio_init_state" value="false"/>
                      </pin_features>
                   </pin>
-                  <pin peripheral="I2C1" signal="SCL" pin_num="115" pin_signal="ADC1_SE6b/PTC10/I2C1_SCL/FTM3_CH6/I2S0_RX_FS/FB_AD5/SDRAM_A13"/>
-                  <pin peripheral="I2C1" signal="SDA" pin_num="116" pin_signal="ADC1_SE7b/PTC11/LLWU_P11/I2C1_SDA/FTM3_CH7/I2S0_RXD1/FB_RW_b"/>
+                  <pin peripheral="I2C1" signal="SCL" pin_num="115" pin_signal="ADC1_SE6b/PTC10/I2C1_SCL/FTM3_CH6/I2S0_RX_FS/FB_AD5/SDRAM_A13">
+                     <pin_features>
+                        <pin_feature name="open_drain" value="enable"/>
+                        <pin_feature name="pull_select" value="up"/>
+                        <pin_feature name="pull_enable" value="enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="I2C1" signal="SDA" pin_num="116" pin_signal="ADC1_SE7b/PTC11/LLWU_P11/I2C1_SDA/FTM3_CH7/I2S0_RXD1/FB_RW_b">
+                     <pin_features>
+                        <pin_feature name="open_drain" value="enable"/>
+                        <pin_feature name="pull_select" value="up"/>
+                        <pin_feature name="pull_enable" value="enable"/>
+                     </pin_features>
+                  </pin>
                   <pin peripheral="I2C3" signal="SCL" pin_num="14" pin_signal="PTE11/I2C3_SCL/I2S0_TX_FS/LPUART0_RTS_b/FTM3_CH6">
                      <pin_features>
                         <pin_feature name="open_drain" value="enable"/>
@@ -192,21 +204,6 @@
                <description></description>
                <options/>
                <dependencies>
-                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C1.i2c_scl" description="Signal serial clock of the peripheral I2C1 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
-                     <feature name="routed" evaluation="">
-                        <data type="Boolean">true</data>
-                     </feature>
-                  </dependency>
-                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C1.i2c_sda" description="Signal serial data of the peripheral I2C1 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
-                     <feature name="routed" evaluation="">
-                        <data type="Boolean">true</data>
-                     </feature>
-                  </dependency>
-                  <dependency resourceType="ClockOutput" resourceId="Bus_clock" description="Bus clock is inactive." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
-                     <feature name="frequency" evaluation="greaterThan">
-                        <data type="Frequency" unit="Hz">0</data>
-                     </feature>
-                  </dependency>
                   <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C3.i2c_scl" description="Signal serial clock of the peripheral I2C3 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
                      <feature name="routed" evaluation="">
                         <data type="Boolean">true</data>
@@ -222,22 +219,37 @@
                         <data type="Frequency" unit="Hz">0</data>
                      </feature>
                   </dependency>
+                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C1.i2c_scl" description="Signal serial clock of the peripheral I2C1 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="routed" evaluation="">
+                        <data type="Boolean">true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C1.i2c_sda" description="Signal serial data of the peripheral I2C1 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="routed" evaluation="">
+                        <data type="Boolean">true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="ClockOutput" resourceId="Bus_clock" description="Bus clock is inactive." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="frequency" evaluation="greaterThan">
+                        <data type="Frequency" unit="Hz">0</data>
+                     </feature>
+                  </dependency>
                </dependencies>
                <instances>
-                  <instance name="I2C1" uuid="1b6bbee3-7e95-461f-88d0-54becedd60fd" type="i2c" type_id="i2c_2566d7363e7e9aaedabb432110e372d7" mode="I2C_Polling" peripheral="I2C1" enabled="true" comment="" custom_name_enabled="false">
-                     <config_set name="fsl_i2c">
+                  <instance name="I2C3" uuid="7b2d7a91-40c6-43b6-9d6c-944a4bc34100" type="i2c" type_id="i2c_2566d7363e7e9aaedabb432110e372d7" mode="I2C_Polling" peripheral="I2C3" enabled="true" comment="" custom_name_enabled="false">
+                     <config_set name="fsl_i2c" quick_selection="QS_I2C_1">
                         <setting name="i2c_mode" value="kI2C_Master"/>
                         <setting name="clockSource" value="BusInterfaceClock"/>
                         <setting name="clockSourceFreq" value="GetFreq"/>
                         <struct name="i2c_master_config">
-                           <setting name="enableMaster" value="false"/>
+                           <setting name="enableMaster" value="true"/>
                            <setting name="enableStopHold" value="false"/>
                            <setting name="baudRate_Bps" value="100000"/>
                            <setting name="glitchFilterWidth" value="0"/>
                         </struct>
                      </config_set>
                   </instance>
-                  <instance name="I2C3" uuid="7b2d7a91-40c6-43b6-9d6c-944a4bc34100" type="i2c" type_id="i2c_2566d7363e7e9aaedabb432110e372d7" mode="I2C_Polling" peripheral="I2C3" enabled="true" comment="" custom_name_enabled="false">
+                  <instance name="I2C1" uuid="976dfa3d-7e12-424f-96a2-166339de9ac9" type="i2c" type_id="i2c_2566d7363e7e9aaedabb432110e372d7" mode="I2C_Polling" peripheral="I2C1" enabled="true" comment="" custom_name_enabled="false">
                      <config_set name="fsl_i2c" quick_selection="QS_I2C_1">
                         <setting name="i2c_mode" value="kI2C_Master"/>
                         <setting name="clockSource" value="BusInterfaceClock"/>

--- a/WB-DAQ-Firmware.mex
+++ b/WB-DAQ-Firmware.mex
@@ -37,6 +37,16 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
+                  <dependency resourceType="Peripheral" resourceId="I2C1" description="Peripheral I2C1 is not initialized" problem_level="1" source="Pins:BOARD_InitPins">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="Peripheral" resourceId="I2C3" description="Peripheral I2C3 is not initialized" problem_level="1" source="Pins:BOARD_InitPins">
+                     <feature name="initialized" evaluation="equal">
+                        <data>true</data>
+                     </feature>
+                  </dependency>
                   <dependency resourceType="SWComponent" resourceId="platform.drivers.common" description="Pins initialization requires the COMMON Driver in the project." problem_level="2" source="Pins:BOARD_InitPins">
                      <feature name="enabled" evaluation="equal" configuration="core0">
                         <data>true</data>
@@ -66,6 +76,22 @@
                         <pin_feature name="identifier" value="HS_SWITCH_B_IN1"/>
                         <pin_feature name="direction" value="OUTPUT"/>
                         <pin_feature name="gpio_init_state" value="false"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="I2C1" signal="SCL" pin_num="115" pin_signal="ADC1_SE6b/PTC10/I2C1_SCL/FTM3_CH6/I2S0_RX_FS/FB_AD5/SDRAM_A13"/>
+                  <pin peripheral="I2C1" signal="SDA" pin_num="116" pin_signal="ADC1_SE7b/PTC11/LLWU_P11/I2C1_SDA/FTM3_CH7/I2S0_RXD1/FB_RW_b"/>
+                  <pin peripheral="I2C3" signal="SCL" pin_num="14" pin_signal="PTE11/I2C3_SCL/I2S0_TX_FS/LPUART0_RTS_b/FTM3_CH6">
+                     <pin_features>
+                        <pin_feature name="open_drain" value="enable"/>
+                        <pin_feature name="pull_select" value="up"/>
+                        <pin_feature name="pull_enable" value="enable"/>
+                     </pin_features>
+                  </pin>
+                  <pin peripheral="I2C3" signal="SDA" pin_num="13" pin_signal="PTE10/LLWU_P18/I2C3_SDA/I2S0_TXD0/LPUART0_CTS_b/FTM3_CH5/USB1_ID">
+                     <pin_features>
+                        <pin_feature name="open_drain" value="enable"/>
+                        <pin_feature name="pull_select" value="up"/>
+                        <pin_feature name="pull_enable" value="enable"/>
                      </pin_features>
                   </pin>
                </pins>
@@ -142,6 +168,18 @@
          <dcdx_configurations/>
       </dcdx>
       <periphs name="Peripherals" version="8.0" enabled="true" update_project_code="true">
+         <dependencies>
+            <dependency resourceType="SWComponent" resourceId="platform.drivers.i2c" description="I2C Driver not found in the toolchain/IDE project. Project will not compile!" problem_level="2" source="Peripherals">
+               <feature name="enabled" evaluation="equal">
+                  <data type="Boolean">true</data>
+               </feature>
+            </dependency>
+            <dependency resourceType="SWComponent" resourceId="platform.drivers.i2c" description="Unsupported version of the I2C Driver in the toolchain/IDE project. Required: ${required_value}, actual: ${actual_value}. Project might not compile correctly." problem_level="1" source="Peripherals">
+               <feature name="version" evaluation="equivalent">
+                  <data type="Version">2.0.5</data>
+               </feature>
+            </dependency>
+         </dependencies>
          <generated_project_files>
             <file path="board/peripherals.c" update_enabled="true"/>
             <file path="board/peripherals.h" update_enabled="true"/>
@@ -153,8 +191,66 @@
             <functional_group name="BOARD_InitPeripherals" uuid="003e09be-8246-4dfc-8d8b-7814e2a4e030" called_from_default_init="true" id_prefix="" core="core0">
                <description></description>
                <options/>
-               <dependencies/>
-               <instances/>
+               <dependencies>
+                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C1.i2c_scl" description="Signal serial clock of the peripheral I2C1 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="routed" evaluation="">
+                        <data type="Boolean">true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C1.i2c_sda" description="Signal serial data of the peripheral I2C1 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="routed" evaluation="">
+                        <data type="Boolean">true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="ClockOutput" resourceId="Bus_clock" description="Bus clock is inactive." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="frequency" evaluation="greaterThan">
+                        <data type="Frequency" unit="Hz">0</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C3.i2c_scl" description="Signal serial clock of the peripheral I2C3 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="routed" evaluation="">
+                        <data type="Boolean">true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="PeripheralUnifiedSignal" resourceId="I2C3.i2c_sda" description="Signal serial data of the peripheral I2C3 is not routed." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="routed" evaluation="">
+                        <data type="Boolean">true</data>
+                     </feature>
+                  </dependency>
+                  <dependency resourceType="ClockOutput" resourceId="Bus_clock" description="Bus clock is inactive." problem_level="1" source="Peripherals:BOARD_InitPeripherals">
+                     <feature name="frequency" evaluation="greaterThan">
+                        <data type="Frequency" unit="Hz">0</data>
+                     </feature>
+                  </dependency>
+               </dependencies>
+               <instances>
+                  <instance name="I2C1" uuid="1b6bbee3-7e95-461f-88d0-54becedd60fd" type="i2c" type_id="i2c_2566d7363e7e9aaedabb432110e372d7" mode="I2C_Polling" peripheral="I2C1" enabled="true" comment="" custom_name_enabled="false">
+                     <config_set name="fsl_i2c">
+                        <setting name="i2c_mode" value="kI2C_Master"/>
+                        <setting name="clockSource" value="BusInterfaceClock"/>
+                        <setting name="clockSourceFreq" value="GetFreq"/>
+                        <struct name="i2c_master_config">
+                           <setting name="enableMaster" value="false"/>
+                           <setting name="enableStopHold" value="false"/>
+                           <setting name="baudRate_Bps" value="100000"/>
+                           <setting name="glitchFilterWidth" value="0"/>
+                        </struct>
+                     </config_set>
+                  </instance>
+                  <instance name="I2C3" uuid="7b2d7a91-40c6-43b6-9d6c-944a4bc34100" type="i2c" type_id="i2c_2566d7363e7e9aaedabb432110e372d7" mode="I2C_Polling" peripheral="I2C3" enabled="true" comment="" custom_name_enabled="false">
+                     <config_set name="fsl_i2c" quick_selection="QS_I2C_1">
+                        <setting name="i2c_mode" value="kI2C_Master"/>
+                        <setting name="clockSource" value="BusInterfaceClock"/>
+                        <setting name="clockSourceFreq" value="GetFreq"/>
+                        <struct name="i2c_master_config">
+                           <setting name="enableMaster" value="true"/>
+                           <setting name="enableStopHold" value="false"/>
+                           <setting name="baudRate_Bps" value="100000"/>
+                           <setting name="glitchFilterWidth" value="0"/>
+                        </struct>
+                     </config_set>
+                  </instance>
+               </instances>
             </functional_group>
          </functional_groups>
          <components>

--- a/board/peripherals.c
+++ b/board/peripherals.c
@@ -37,43 +37,6 @@ component:
  * BOARD_InitPeripherals functional group
  **********************************************************************************************************************/
 /***********************************************************************************************************************
- * I2C1 initialization code
- **********************************************************************************************************************/
-/* clang-format off */
-/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
-instance:
-- name: 'I2C1'
-- type: 'i2c'
-- mode: 'I2C_Polling'
-- custom_name_enabled: 'false'
-- type_id: 'i2c_2566d7363e7e9aaedabb432110e372d7'
-- functional_group: 'BOARD_InitPeripherals'
-- peripheral: 'I2C1'
-- config_sets:
-  - fsl_i2c:
-    - i2c_mode: 'kI2C_Master'
-    - clockSource: 'BusInterfaceClock'
-    - clockSourceFreq: 'GetFreq'
-    - i2c_master_config:
-      - enableMaster: 'false'
-      - enableStopHold: 'false'
-      - baudRate_Bps: '100000'
-      - glitchFilterWidth: '0'
- * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
-/* clang-format on */
-const i2c_master_config_t I2C1_config = {
-  .enableMaster = false,
-  .enableStopHold = false,
-  .baudRate_Bps = 100000UL,
-  .glitchFilterWidth = 0U
-};
-
-static void I2C1_init(void) {
-  /* Initialization function */
-  I2C_MasterInit(I2C1_PERIPHERAL, &I2C1_config, I2C1_CLK_FREQ);
-}
-
-/***********************************************************************************************************************
  * I2C3 initialization code
  **********************************************************************************************************************/
 /* clang-format off */
@@ -112,13 +75,51 @@ static void I2C3_init(void) {
 }
 
 /***********************************************************************************************************************
+ * I2C1 initialization code
+ **********************************************************************************************************************/
+/* clang-format off */
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+instance:
+- name: 'I2C1'
+- type: 'i2c'
+- mode: 'I2C_Polling'
+- custom_name_enabled: 'false'
+- type_id: 'i2c_2566d7363e7e9aaedabb432110e372d7'
+- functional_group: 'BOARD_InitPeripherals'
+- peripheral: 'I2C1'
+- config_sets:
+  - fsl_i2c:
+    - i2c_mode: 'kI2C_Master'
+    - clockSource: 'BusInterfaceClock'
+    - clockSourceFreq: 'GetFreq'
+    - i2c_master_config:
+      - enableMaster: 'true'
+      - enableStopHold: 'false'
+      - baudRate_Bps: '100000'
+      - glitchFilterWidth: '0'
+    - quick_selection: 'QS_I2C_1'
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+/* clang-format on */
+const i2c_master_config_t I2C1_config = {
+  .enableMaster = true,
+  .enableStopHold = false,
+  .baudRate_Bps = 100000UL,
+  .glitchFilterWidth = 0U
+};
+
+static void I2C1_init(void) {
+  /* Initialization function */
+  I2C_MasterInit(I2C1_PERIPHERAL, &I2C1_config, I2C1_CLK_FREQ);
+}
+
+/***********************************************************************************************************************
  * Initialization functions
  **********************************************************************************************************************/
 void BOARD_InitPeripherals(void)
 {
   /* Initialize components */
-  I2C1_init();
   I2C3_init();
+  I2C1_init();
 }
 
 /***********************************************************************************************************************

--- a/board/peripherals.c
+++ b/board/peripherals.c
@@ -34,10 +34,91 @@ component:
 #include "peripherals.h"
 
 /***********************************************************************************************************************
+ * BOARD_InitPeripherals functional group
+ **********************************************************************************************************************/
+/***********************************************************************************************************************
+ * I2C1 initialization code
+ **********************************************************************************************************************/
+/* clang-format off */
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+instance:
+- name: 'I2C1'
+- type: 'i2c'
+- mode: 'I2C_Polling'
+- custom_name_enabled: 'false'
+- type_id: 'i2c_2566d7363e7e9aaedabb432110e372d7'
+- functional_group: 'BOARD_InitPeripherals'
+- peripheral: 'I2C1'
+- config_sets:
+  - fsl_i2c:
+    - i2c_mode: 'kI2C_Master'
+    - clockSource: 'BusInterfaceClock'
+    - clockSourceFreq: 'GetFreq'
+    - i2c_master_config:
+      - enableMaster: 'false'
+      - enableStopHold: 'false'
+      - baudRate_Bps: '100000'
+      - glitchFilterWidth: '0'
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+/* clang-format on */
+const i2c_master_config_t I2C1_config = {
+  .enableMaster = false,
+  .enableStopHold = false,
+  .baudRate_Bps = 100000UL,
+  .glitchFilterWidth = 0U
+};
+
+static void I2C1_init(void) {
+  /* Initialization function */
+  I2C_MasterInit(I2C1_PERIPHERAL, &I2C1_config, I2C1_CLK_FREQ);
+}
+
+/***********************************************************************************************************************
+ * I2C3 initialization code
+ **********************************************************************************************************************/
+/* clang-format off */
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+instance:
+- name: 'I2C3'
+- type: 'i2c'
+- mode: 'I2C_Polling'
+- custom_name_enabled: 'false'
+- type_id: 'i2c_2566d7363e7e9aaedabb432110e372d7'
+- functional_group: 'BOARD_InitPeripherals'
+- peripheral: 'I2C3'
+- config_sets:
+  - fsl_i2c:
+    - i2c_mode: 'kI2C_Master'
+    - clockSource: 'BusInterfaceClock'
+    - clockSourceFreq: 'GetFreq'
+    - i2c_master_config:
+      - enableMaster: 'true'
+      - enableStopHold: 'false'
+      - baudRate_Bps: '100000'
+      - glitchFilterWidth: '0'
+    - quick_selection: 'QS_I2C_1'
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+/* clang-format on */
+const i2c_master_config_t I2C3_config = {
+  .enableMaster = true,
+  .enableStopHold = false,
+  .baudRate_Bps = 100000UL,
+  .glitchFilterWidth = 0U
+};
+
+static void I2C3_init(void) {
+  /* Initialization function */
+  I2C_MasterInit(I2C3_PERIPHERAL, &I2C3_config, I2C3_CLK_FREQ);
+}
+
+/***********************************************************************************************************************
  * Initialization functions
  **********************************************************************************************************************/
 void BOARD_InitPeripherals(void)
 {
+  /* Initialize components */
+  I2C1_init();
+  I2C3_init();
 }
 
 /***********************************************************************************************************************

--- a/board/peripherals.h
+++ b/board/peripherals.h
@@ -20,13 +20,6 @@ extern "C" {
  * Definitions
  **********************************************************************************************************************/
 /* Definitions for BOARD_InitPeripherals functional group */
-/* BOARD_InitPeripherals defines for I2C1 */
-/* Definition of peripheral ID */
-#define I2C1_PERIPHERAL I2C1
-/* Definition of the clock source */
-#define I2C1_CLOCK_SOURCE I2C1_CLK_SRC
-/* Definition of the clock source frequency */
-#define I2C1_CLK_FREQ CLOCK_GetFreq(I2C1_CLOCK_SOURCE)
 /* BOARD_InitPeripherals defines for I2C3 */
 /* Definition of peripheral ID */
 #define I2C3_PERIPHERAL I2C3
@@ -34,12 +27,19 @@ extern "C" {
 #define I2C3_CLOCK_SOURCE I2C3_CLK_SRC
 /* Definition of the clock source frequency */
 #define I2C3_CLK_FREQ CLOCK_GetFreq(I2C3_CLOCK_SOURCE)
+/* BOARD_InitPeripherals defines for I2C1 */
+/* Definition of peripheral ID */
+#define I2C1_PERIPHERAL I2C1
+/* Definition of the clock source */
+#define I2C1_CLOCK_SOURCE I2C1_CLK_SRC
+/* Definition of the clock source frequency */
+#define I2C1_CLK_FREQ CLOCK_GetFreq(I2C1_CLOCK_SOURCE)
 
 /***********************************************************************************************************************
  * Global variables
  **********************************************************************************************************************/
-extern const i2c_master_config_t I2C1_config;
 extern const i2c_master_config_t I2C3_config;
+extern const i2c_master_config_t I2C1_config;
 
 /***********************************************************************************************************************
  * Initialization functions

--- a/board/peripherals.h
+++ b/board/peripherals.h
@@ -6,9 +6,40 @@
 #ifndef _PERIPHERALS_H_
 #define _PERIPHERALS_H_
 
+/***********************************************************************************************************************
+ * Included files
+ **********************************************************************************************************************/
+#include "fsl_common.h"
+#include "fsl_i2c.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /* __cplusplus */
+
+/***********************************************************************************************************************
+ * Definitions
+ **********************************************************************************************************************/
+/* Definitions for BOARD_InitPeripherals functional group */
+/* BOARD_InitPeripherals defines for I2C1 */
+/* Definition of peripheral ID */
+#define I2C1_PERIPHERAL I2C1
+/* Definition of the clock source */
+#define I2C1_CLOCK_SOURCE I2C1_CLK_SRC
+/* Definition of the clock source frequency */
+#define I2C1_CLK_FREQ CLOCK_GetFreq(I2C1_CLOCK_SOURCE)
+/* BOARD_InitPeripherals defines for I2C3 */
+/* Definition of peripheral ID */
+#define I2C3_PERIPHERAL I2C3
+/* Definition of the clock source */
+#define I2C3_CLOCK_SOURCE I2C3_CLK_SRC
+/* Definition of the clock source frequency */
+#define I2C3_CLK_FREQ CLOCK_GetFreq(I2C3_CLOCK_SOURCE)
+
+/***********************************************************************************************************************
+ * Global variables
+ **********************************************************************************************************************/
+extern const i2c_master_config_t I2C1_config;
+extern const i2c_master_config_t I2C3_config;
 
 /***********************************************************************************************************************
  * Initialization functions

--- a/board/pin_mux.c
+++ b/board/pin_mux.c
@@ -46,6 +46,11 @@ BOARD_InitPins:
     direction: OUTPUT, gpio_init_state: 'true'}
   - {pin_num: '110', peripheral: GPIOC, signal: 'GPIO, 5', pin_signal: PTC5/LLWU_P9/SPI0_SCK/LPTMR0_ALT2/I2S0_RXD0/FB_AD10/SDRAM_A18/CMP0_OUT/FTM0_CH2, identifier: HS_SWITCH_B_IN1,
     direction: OUTPUT, gpio_init_state: 'false'}
+  - {pin_num: '115', peripheral: I2C1, signal: SCL, pin_signal: ADC1_SE6b/PTC10/I2C1_SCL/FTM3_CH6/I2S0_RX_FS/FB_AD5/SDRAM_A13}
+  - {pin_num: '116', peripheral: I2C1, signal: SDA, pin_signal: ADC1_SE7b/PTC11/LLWU_P11/I2C1_SDA/FTM3_CH7/I2S0_RXD1/FB_RW_b}
+  - {pin_num: '14', peripheral: I2C3, signal: SCL, pin_signal: PTE11/I2C3_SCL/I2S0_TX_FS/LPUART0_RTS_b/FTM3_CH6, open_drain: enable, pull_select: up, pull_enable: enable}
+  - {pin_num: '13', peripheral: I2C3, signal: SDA, pin_signal: PTE10/LLWU_P18/I2C3_SDA/I2S0_TXD0/LPUART0_CTS_b/FTM3_CH5/USB1_ID, open_drain: enable, pull_select: up,
+    pull_enable: enable}
  * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS ***********
  */
 /* clang-format on */
@@ -60,6 +65,8 @@ void BOARD_InitPins(void)
 {
     /* Port C Clock Gate Control: Clock enabled */
     CLOCK_EnableClock(kCLOCK_PortC);
+    /* Port E Clock Gate Control: Clock enabled */
+    CLOCK_EnableClock(kCLOCK_PortE);
 
     gpio_pin_config_t HS_SWITCH_B_IN1_config = {
         .pinDirection = kGPIO_DigitalOutput,
@@ -75,11 +82,47 @@ void BOARD_InitPins(void)
     /* Initialize GPIO functionality on pin PTC6 (pin 111)  */
     GPIO_PinInit(BOARD_INITPINS_HS_SWITCH_B_IN0_GPIO, BOARD_INITPINS_HS_SWITCH_B_IN0_PIN, &HS_SWITCH_B_IN0_config);
 
+    /* PORTC10 (pin 115) is configured as I2C1_SCL */
+    PORT_SetPinMux(PORTC, 10U, kPORT_MuxAlt2);
+
+    /* PORTC11 (pin 116) is configured as I2C1_SDA */
+    PORT_SetPinMux(PORTC, 11U, kPORT_MuxAlt2);
+
     /* PORTC5 (pin 110) is configured as PTC5 */
     PORT_SetPinMux(BOARD_INITPINS_HS_SWITCH_B_IN1_PORT, BOARD_INITPINS_HS_SWITCH_B_IN1_PIN, kPORT_MuxAsGpio);
 
     /* PORTC6 (pin 111) is configured as PTC6 */
     PORT_SetPinMux(BOARD_INITPINS_HS_SWITCH_B_IN0_PORT, BOARD_INITPINS_HS_SWITCH_B_IN0_PIN, kPORT_MuxAsGpio);
+
+    /* PORTE10 (pin 13) is configured as I2C3_SDA */
+    PORT_SetPinMux(PORTE, 10U, kPORT_MuxAlt2);
+
+    PORTE->PCR[10] = ((PORTE->PCR[10] &
+                       /* Mask bits to zero which are setting */
+                       (~(PORT_PCR_PS_MASK | PORT_PCR_PE_MASK | PORT_PCR_ODE_MASK | PORT_PCR_ISF_MASK)))
+
+                      /* Pull Select: Internal pullup resistor is enabled on the corresponding pin, if the
+                       * corresponding PE field is set. */
+                      | (uint32_t)(kPORT_PullUp)
+
+                      /* Open Drain Enable: Open drain output is enabled on the corresponding pin, if the pin is
+                       * configured as a digital output. */
+                      | PORT_PCR_ODE(kPORT_OpenDrainEnable));
+
+    /* PORTE11 (pin 14) is configured as I2C3_SCL */
+    PORT_SetPinMux(PORTE, 11U, kPORT_MuxAlt2);
+
+    PORTE->PCR[11] = ((PORTE->PCR[11] &
+                       /* Mask bits to zero which are setting */
+                       (~(PORT_PCR_PS_MASK | PORT_PCR_PE_MASK | PORT_PCR_ODE_MASK | PORT_PCR_ISF_MASK)))
+
+                      /* Pull Select: Internal pullup resistor is enabled on the corresponding pin, if the
+                       * corresponding PE field is set. */
+                      | (uint32_t)(kPORT_PullUp)
+
+                      /* Open Drain Enable: Open drain output is enabled on the corresponding pin, if the pin is
+                       * configured as a digital output. */
+                      | PORT_PCR_ODE(kPORT_OpenDrainEnable));
 }
 /***********************************************************************************************************************
  * EOF

--- a/board/pin_mux.c
+++ b/board/pin_mux.c
@@ -46,8 +46,10 @@ BOARD_InitPins:
     direction: OUTPUT, gpio_init_state: 'true'}
   - {pin_num: '110', peripheral: GPIOC, signal: 'GPIO, 5', pin_signal: PTC5/LLWU_P9/SPI0_SCK/LPTMR0_ALT2/I2S0_RXD0/FB_AD10/SDRAM_A18/CMP0_OUT/FTM0_CH2, identifier: HS_SWITCH_B_IN1,
     direction: OUTPUT, gpio_init_state: 'false'}
-  - {pin_num: '115', peripheral: I2C1, signal: SCL, pin_signal: ADC1_SE6b/PTC10/I2C1_SCL/FTM3_CH6/I2S0_RX_FS/FB_AD5/SDRAM_A13}
-  - {pin_num: '116', peripheral: I2C1, signal: SDA, pin_signal: ADC1_SE7b/PTC11/LLWU_P11/I2C1_SDA/FTM3_CH7/I2S0_RXD1/FB_RW_b}
+  - {pin_num: '115', peripheral: I2C1, signal: SCL, pin_signal: ADC1_SE6b/PTC10/I2C1_SCL/FTM3_CH6/I2S0_RX_FS/FB_AD5/SDRAM_A13, open_drain: enable, pull_select: up,
+    pull_enable: enable}
+  - {pin_num: '116', peripheral: I2C1, signal: SDA, pin_signal: ADC1_SE7b/PTC11/LLWU_P11/I2C1_SDA/FTM3_CH7/I2S0_RXD1/FB_RW_b, open_drain: enable, pull_select: up,
+    pull_enable: enable}
   - {pin_num: '14', peripheral: I2C3, signal: SCL, pin_signal: PTE11/I2C3_SCL/I2S0_TX_FS/LPUART0_RTS_b/FTM3_CH6, open_drain: enable, pull_select: up, pull_enable: enable}
   - {pin_num: '13', peripheral: I2C3, signal: SDA, pin_signal: PTE10/LLWU_P18/I2C3_SDA/I2S0_TXD0/LPUART0_CTS_b/FTM3_CH5/USB1_ID, open_drain: enable, pull_select: up,
     pull_enable: enable}
@@ -85,8 +87,32 @@ void BOARD_InitPins(void)
     /* PORTC10 (pin 115) is configured as I2C1_SCL */
     PORT_SetPinMux(PORTC, 10U, kPORT_MuxAlt2);
 
+    PORTC->PCR[10] = ((PORTC->PCR[10] &
+                       /* Mask bits to zero which are setting */
+                       (~(PORT_PCR_PS_MASK | PORT_PCR_PE_MASK | PORT_PCR_ODE_MASK | PORT_PCR_ISF_MASK)))
+
+                      /* Pull Select: Internal pullup resistor is enabled on the corresponding pin, if the
+                       * corresponding PE field is set. */
+                      | (uint32_t)(kPORT_PullUp)
+
+                      /* Open Drain Enable: Open drain output is enabled on the corresponding pin, if the pin is
+                       * configured as a digital output. */
+                      | PORT_PCR_ODE(kPORT_OpenDrainEnable));
+
     /* PORTC11 (pin 116) is configured as I2C1_SDA */
     PORT_SetPinMux(PORTC, 11U, kPORT_MuxAlt2);
+
+    PORTC->PCR[11] = ((PORTC->PCR[11] &
+                       /* Mask bits to zero which are setting */
+                       (~(PORT_PCR_PS_MASK | PORT_PCR_PE_MASK | PORT_PCR_ODE_MASK | PORT_PCR_ISF_MASK)))
+
+                      /* Pull Select: Internal pullup resistor is enabled on the corresponding pin, if the
+                       * corresponding PE field is set. */
+                      | (uint32_t)(kPORT_PullUp)
+
+                      /* Open Drain Enable: Open drain output is enabled on the corresponding pin, if the pin is
+                       * configured as a digital output. */
+                      | PORT_PCR_ODE(kPORT_OpenDrainEnable));
 
     /* PORTC5 (pin 110) is configured as PTC5 */
     PORT_SetPinMux(BOARD_INITPINS_HS_SWITCH_B_IN1_PORT, BOARD_INITPINS_HS_SWITCH_B_IN1_PIN, kPORT_MuxAsGpio);

--- a/drivers/freertos/fsl_i2c_freertos.c
+++ b/drivers/freertos/fsl_i2c_freertos.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_i2c_freertos.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.i2c_freertos"
+#endif
+
+static void I2C_RTOS_Callback(I2C_Type *base, i2c_master_handle_t *drv_handle, status_t status, void *userData)
+{
+    i2c_rtos_handle_t *handle = (i2c_rtos_handle_t *)userData;
+    BaseType_t reschedule;
+    handle->async_status = status;
+    xSemaphoreGiveFromISR(handle->semaphore, &reschedule);
+    portYIELD_FROM_ISR(reschedule);
+}
+
+/*!
+ * brief Initializes I2C.
+ *
+ * This function initializes the I2C module and the related RTOS context.
+ *
+ * param handle The RTOS I2C handle, the pointer to an allocated space for RTOS context.
+ * param base The pointer base address of the I2C instance to initialize.
+ * param masterConfig The configuration structure to set-up I2C in master mode.
+ * param srcClock_Hz The frequency of an input clock of the I2C module.
+ * return status of the operation.
+ */
+status_t I2C_RTOS_Init(i2c_rtos_handle_t *handle,
+                       I2C_Type *base,
+                       const i2c_master_config_t *masterConfig,
+                       uint32_t srcClock_Hz)
+{
+    if (handle == NULL)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    if (base == NULL)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    memset(handle, 0, sizeof(i2c_rtos_handle_t));
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    handle->mutex = xSemaphoreCreateMutexStatic(&handle->mutexBuffer);
+#else
+    handle->mutex     = xSemaphoreCreateMutex();
+#endif
+    if (handle->mutex == NULL)
+    {
+        return kStatus_Fail;
+    }
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    handle->semaphore = xSemaphoreCreateBinaryStatic(&handle->semaphoreBuffer);
+#else
+    handle->semaphore = xSemaphoreCreateBinary();
+#endif
+    if (handle->semaphore == NULL)
+    {
+        vSemaphoreDelete(handle->mutex);
+        return kStatus_Fail;
+    }
+
+    handle->base = base;
+
+    I2C_MasterInit(handle->base, masterConfig, srcClock_Hz);
+    I2C_MasterTransferCreateHandle(base, &handle->drv_handle, I2C_RTOS_Callback, (void *)handle);
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Deinitializes the I2C.
+ *
+ * This function deinitializes the I2C module and the related RTOS context.
+ *
+ * param handle The RTOS I2C handle.
+ */
+status_t I2C_RTOS_Deinit(i2c_rtos_handle_t *handle)
+{
+    I2C_MasterDeinit(handle->base);
+
+    vSemaphoreDelete(handle->semaphore);
+    vSemaphoreDelete(handle->mutex);
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Performs the I2C transfer.
+ *
+ * This function performs the I2C transfer according to the data given in the transfer structure.
+ *
+ * param handle The RTOS I2C handle.
+ * param transfer A structure specifying the transfer parameters.
+ * return status of the operation.
+ */
+status_t I2C_RTOS_Transfer(i2c_rtos_handle_t *handle, i2c_master_transfer_t *transfer)
+{
+    status_t status;
+
+    /* Lock resource mutex */
+    if (xSemaphoreTake(handle->mutex, portMAX_DELAY) != pdTRUE)
+    {
+        return kStatus_I2C_Busy;
+    }
+
+    status = I2C_MasterTransferNonBlocking(handle->base, &handle->drv_handle, transfer);
+    if (status != kStatus_Success)
+    {
+        xSemaphoreGive(handle->mutex);
+        return status;
+    }
+
+    /* Wait for transfer to finish */
+    (void)xSemaphoreTake(handle->semaphore, portMAX_DELAY);
+
+    /* Unlock resource mutex */
+    xSemaphoreGive(handle->mutex);
+
+    /* Return status captured by callback function */
+    return handle->async_status;
+}

--- a/drivers/freertos/fsl_i2c_freertos.h
+++ b/drivers/freertos/fsl_i2c_freertos.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2020 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef __FSL_I2C_FREERTOS_H__
+#define __FSL_I2C_FREERTOS_H__
+
+#include "FreeRTOS.h"
+#include "portable.h"
+#include "semphr.h"
+
+#include "fsl_i2c.h"
+
+/*!
+ * @addtogroup i2c_freertos_driver I2C FreeRTOS Driver
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief I2C FreeRTOS driver version 2.0.8. */
+#define FSL_I2C_FREERTOS_DRIVER_VERSION (MAKE_VERSION(2, 0, 8))
+/*@}*/
+
+/*!
+ * @cond RTOS_PRIVATE
+ * @brief I2C FreeRTOS handle
+ */
+typedef struct _i2c_rtos_handle
+{
+    I2C_Type *base;                 /*!< I2C base address */
+    i2c_master_handle_t drv_handle; /*!< A handle of the underlying driver, treated as opaque by the RTOS layer */
+    status_t async_status;          /*!< Transactional state of the underlying driver */
+    SemaphoreHandle_t mutex;        /*!< A mutex to lock the handle during a transfer */
+    SemaphoreHandle_t semaphore;    /*!< A semaphore to notify and unblock task when the transfer ends */
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    StaticSemaphore_t mutexBuffer;     /*!< Statically allocated memory for mutex */
+    StaticSemaphore_t semaphoreBuffer; /*!< Statically allocated memory for semaphore */
+#endif
+} i2c_rtos_handle_t;
+/*! \endcond */
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name I2C RTOS Operation
+ * @{
+ */
+
+/*!
+ * @brief Initializes I2C.
+ *
+ * This function initializes the I2C module and the related RTOS context.
+ *
+ * @param handle The RTOS I2C handle, the pointer to an allocated space for RTOS context.
+ * @param base The pointer base address of the I2C instance to initialize.
+ * @param masterConfig The configuration structure to set-up I2C in master mode.
+ * @param srcClock_Hz The frequency of an input clock of the I2C module.
+ * @return status of the operation.
+ */
+status_t I2C_RTOS_Init(i2c_rtos_handle_t *handle,
+                       I2C_Type *base,
+                       const i2c_master_config_t *masterConfig,
+                       uint32_t srcClock_Hz);
+
+/*!
+ * @brief Deinitializes the I2C.
+ *
+ * This function deinitializes the I2C module and the related RTOS context.
+ *
+ * @param handle The RTOS I2C handle.
+ */
+status_t I2C_RTOS_Deinit(i2c_rtos_handle_t *handle);
+
+/*!
+ * @brief Performs the I2C transfer.
+ *
+ * This function performs the I2C transfer according to the data given in the transfer structure.
+ *
+ * @param handle The RTOS I2C handle.
+ * @param transfer A structure specifying the transfer parameters.
+ * @return status of the operation.
+ */
+status_t I2C_RTOS_Transfer(i2c_rtos_handle_t *handle, i2c_master_transfer_t *transfer);
+
+/*!
+ * @}
+ */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*!
+ * @}
+ */
+
+#endif /* __FSL_I2C_FREERTOS_H__ */

--- a/drivers/fsl_i2c.c
+++ b/drivers/fsl_i2c.c
@@ -1,0 +1,2423 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "fsl_i2c.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.i2c"
+#endif
+
+/*! @brief i2c transfer state. */
+enum _i2c_transfer_states
+{
+    kIdleState             = 0x0U, /*!< I2C bus idle. */
+    kCheckAddressState     = 0x1U, /*!< 7-bit address check state. */
+    kSendCommandState      = 0x2U, /*!< Send command byte phase. */
+    kSendDataState         = 0x3U, /*!< Send data transfer phase. */
+    kReceiveDataBeginState = 0x4U, /*!< Receive data transfer phase begin. */
+    kReceiveDataState      = 0x5U, /*!< Receive data transfer phase. */
+};
+
+/*! @brief Typedef for interrupt handler. */
+typedef void (*i2c_isr_t)(I2C_Type *base, void *i2cHandle);
+
+/*! @brief static variable to keep current configured baudrate. */
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+static uint32_t g_baudrate = 100000;
+#endif
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Set SCL/SDA hold time, this API receives SCL stop hold time, calculate the
+ * closest SCL divider and MULT value for the SDA hold time, SCL start and SCL stop
+ * hold time. To reduce the ROM size, SDA/SCL hold value mapping table is not provided,
+ * assume SCL divider = SCL stop hold value *2 to get the closest SCL divider value and MULT
+ * value, then the related SDA hold time, SCL start and SCL stop hold time is used.
+ *
+ * @param base I2C peripheral base address.
+ * @param sourceClock_Hz I2C functional clock frequency in Hertz.
+ * @param sclStopHoldTime_ns SCL stop hold time in ns.
+ */
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz);
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+/*!
+ * @brief I2C master manually ack byte.
+ *
+ * @param base I2C peripheral base address.
+ * @param dummy Data pointer to save dummy read data register
+ */
+static void I2C_MasterAckByte(I2C_Type *base, volatile uint8_t *dummy);
+#endif
+
+/*!
+ * @brief Set up master transfer, send slave address and decide the initial
+ * transfer state.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * @param xfer pointer to i2c_master_transfer_t structure.
+ */
+static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer);
+
+/*!
+ * @brief Check and clear status operation.
+ *
+ * @param base I2C peripheral base address.
+ * @param status current i2c hardware status.
+ * @retval kStatus_Success No error found.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStatus_I2C_Nak Received Nak error.
+ */
+static status_t I2C_CheckAndClearError(I2C_Type *base, uint32_t status);
+
+/*!
+ * @brief Master run transfer state machine to perform a byte of transfer.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ * @param isDone input param to get whether the thing is done, true is done
+ * @retval kStatus_Success No error found.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStatus_I2C_Nak Received Nak error.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ */
+static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_handle_t *handle, bool *isDone);
+
+/*!
+ * @brief I2C common interrupt handler.
+ *
+ * @param base I2C peripheral base address.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ */
+static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to i2c handles for each instance. */
+static void *s_i2cHandle[FSL_FEATURE_SOC_I2C_COUNT];
+
+/*! @brief SCL clock divider used to calculate baudrate. */
+static const uint16_t s_i2cDividerTable[] = {
+    20,  22,  24,  26,   28,   30,   34,   40,   28,   32,   36,   40,   44,   48,   56,   68,
+    48,  56,  64,  72,   80,   88,   104,  128,  80,   96,   112,  128,  144,  160,  192,  240,
+    160, 192, 224, 256,  288,  320,  384,  480,  320,  384,  448,  512,  576,  640,  768,  960,
+    640, 768, 896, 1024, 1152, 1280, 1536, 1920, 1280, 1536, 1792, 2048, 2304, 2560, 3072, 3840};
+
+/*! @brief Pointers to i2c IRQ number for each instance. */
+static const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+/*! @brief Pointers to i2c clocks for each instance. */
+static const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+/*! @brief Pointer to master IRQ handler for each instance. */
+static i2c_isr_t s_i2cMasterIsr;
+
+/*! @brief Pointer to slave IRQ handler for each instance. */
+static i2c_isr_t s_i2cSlaveIsr;
+
+/*! @brief Pointers to i2c bases for each instance. */
+static I2C_Type *const s_i2cBases[] = I2C_BASE_PTRS;
+/*******************************************************************************
+ * Codes
+ ******************************************************************************/
+
+/*!
+ * brief Get instance number for I2C module.
+ *
+ * param base I2C peripheral base address.
+ */
+uint32_t I2C_GetInstance(I2C_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
+    {
+        if (s_i2cBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_i2cBases));
+
+    return instance;
+}
+
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedSclHoldTime;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult  = 0u;
+    uint32_t bestIcr   = 0u;
+    uint32_t u32flag   = 1u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    /* SDA hold time = bus period (s) * mul * SDA hold value. */
+    /* SCL start hold time = bus period (s) * mul * SCL start hold value. */
+    /* SCL stop hold time = bus period (s) * mul * SCL stop hold value. */
+
+    for (mult = 0u; mult <= 2u; ++mult)
+    {
+        if (bestError == 0u)
+        {
+            break;
+        }
+
+        multiplier = u32flag << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(s_i2cDividerTable[0]); ++i)
+        {
+            /* Assume SCL hold(stop) value = s_i2cDividerTable[i]/2. */
+            computedSclHoldTime = ((multiplier * s_i2cDividerTable[i]) * 500000U) / (sourceClock_Hz / 1000U);
+            absError = sclStopHoldTime_ns > computedSclHoldTime ? (sclStopHoldTime_ns - computedSclHoldTime) :
+                                                                  (computedSclHoldTime - sclStopHoldTime_ns);
+
+            if (absError < bestError)
+            {
+                bestMult  = mult;
+                bestIcr   = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0u)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
+}
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+static void I2C_MasterAckByte(I2C_Type *base, volatile uint8_t *dummy)
+{
+    /* Clear the TXAK flag. */
+    base->C1 &= ~(uint8_t)I2C_C1_TXAK_MASK;
+
+    /* Delay at least one bit time */
+    SDK_DelayAtLeastUs(1000000 / g_baudrate, SystemCoreClock);
+
+    /* Do dummy read. */
+    *dummy = base->D;
+}
+#endif
+
+static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
+{
+    status_t result           = kStatus_Success;
+    i2c_direction_t direction = xfer->direction;
+
+    /* Initialize the handle transfer information. */
+    handle->transfer = *xfer;
+
+    /* Save total transfer size. */
+    handle->transferSize = xfer->dataSize;
+
+    /* Initial transfer state. */
+    if (handle->transfer.subaddressSize > 0u)
+    {
+        if (xfer->direction == kI2C_Read)
+        {
+            direction = kI2C_Write;
+        }
+    }
+
+    handle->state = (uint8_t)kCheckAddressState;
+
+    /* Clear all status before transfer. */
+    I2C_MasterClearStatusFlags(base, (uint32_t)kClearFlags);
+
+    /* Handle no start option. */
+    if (0U != (handle->transfer.flags & (uint32_t)kI2C_TransferNoStartFlag))
+    {
+        /* No need to send start flag, directly go to send command or data */
+        if (handle->transfer.subaddressSize > 0u)
+        {
+            handle->state = (uint8_t)kSendCommandState;
+        }
+        else
+        {
+            if (direction == kI2C_Write)
+            {
+                /* Next state, send data. */
+                handle->state = (uint8_t)kSendDataState;
+            }
+            else
+            {
+                /* Only support write with no stop signal. */
+                return kStatus_InvalidArgument;
+            }
+        }
+
+        /* Wait for TCF bit and manually trigger tx interrupt. */
+#if I2C_RETRY_TIMES
+        uint32_t waitTimes = I2C_RETRY_TIMES;
+        while ((0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        while (0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag))
+        {
+        }
+#endif
+        I2C_MasterTransferHandleIRQ(base, handle);
+    }
+    /* If repeated start is requested, send repeated start. */
+    else if (0U != (handle->transfer.flags & (uint32_t)kI2C_TransferRepeatedStartFlag))
+    {
+        result = I2C_MasterRepeatedStart(base, handle->transfer.slaveAddress, direction);
+    }
+    else /* For normal transfer, send start. */
+    {
+        result = I2C_MasterStart(base, handle->transfer.slaveAddress, direction);
+    }
+
+    return result;
+}
+
+static status_t I2C_CheckAndClearError(I2C_Type *base, uint32_t status)
+{
+    status_t result = kStatus_Success;
+
+    /* Check arbitration lost. */
+    if (0U != (status & (uint32_t)kI2C_ArbitrationLostFlag))
+    {
+        /* Clear arbitration lost flag. */
+        base->S = (uint8_t)kI2C_ArbitrationLostFlag;
+        result  = kStatus_I2C_ArbitrationLost;
+    }
+    /* Check NAK */
+    else if (0U != (status & (uint32_t)kI2C_ReceiveNakFlag))
+    {
+        result = kStatus_I2C_Nak;
+    }
+    else
+    {
+        /* Add this to fix MISRA C2012 rule15.7 issue: Empty else without comment. */
+    }
+
+    return result;
+}
+
+static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_handle_t *handle, bool *isDone)
+{
+    status_t result        = kStatus_Success;
+    uint32_t statusFlags   = base->S;
+    *isDone                = false;
+    volatile uint8_t dummy = 0;
+    uint32_t tmpDataSize   = handle->transfer.dataSize;
+    bool ignoreNak         = ((handle->state == (uint8_t)kSendDataState) && (tmpDataSize == 0U)) ||
+                     ((handle->state == (uint8_t)kReceiveDataState) && (tmpDataSize == 1U));
+    uint8_t tmpdata;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    /* Check & clear error flags. */
+    result = I2C_CheckAndClearError(base, statusFlags);
+
+    /* Ignore Nak when it's appeared for last byte. */
+    if ((result == kStatus_I2C_Nak) && ignoreNak)
+    {
+        result = kStatus_Success;
+    }
+
+    /* Handle Check address state to check the slave address is Acked in slave
+       probe application. */
+    if (handle->state == (uint8_t)kCheckAddressState)
+    {
+        if (0U != (statusFlags & (uint8_t)kI2C_ReceiveNakFlag))
+        {
+            result = kStatus_I2C_Addr_Nak;
+        }
+        else
+        {
+            if (handle->transfer.subaddressSize > 0U)
+            {
+                handle->state = (uint8_t)kSendCommandState;
+            }
+            else
+            {
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Next state, send data. */
+                    handle->state = (uint8_t)kSendDataState;
+                }
+                else
+                {
+                    /* Next state, receive data begin. */
+                    handle->state = (uint8_t)kReceiveDataBeginState;
+                }
+            }
+        }
+    }
+
+    if (kStatus_Success != result)
+    {
+        return result;
+    }
+
+    /* Run state machine. */
+    switch (handle->state)
+    {
+        /* Send I2C command. */
+        case (uint8_t)kSendCommandState:
+            if (0U != (handle->transfer.subaddressSize))
+            {
+                handle->transfer.subaddressSize--;
+                base->D = (uint8_t)((handle->transfer.subaddress) >> (8U * handle->transfer.subaddressSize));
+            }
+            else
+            {
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Send first byte of data. */
+                    if (handle->transfer.dataSize > 0U)
+                    {
+                        /* Next state, send data. */
+                        handle->state = (uint8_t)kSendDataState;
+                        base->D       = *handle->transfer.data;
+                        handle->transfer.data++;
+                        handle->transfer.dataSize--;
+                    }
+                    else
+                    {
+                        *isDone = true;
+                    }
+                }
+                else
+                {
+                    /* Send repeated start and slave address. */
+                    result = I2C_MasterRepeatedStart(base, handle->transfer.slaveAddress, kI2C_Read);
+
+                    /* Next state, receive data begin. */
+                    handle->state = (uint8_t)kReceiveDataBeginState;
+                }
+            }
+            break;
+
+        /* Send I2C data. */
+        case (uint8_t)kSendDataState:
+            /* Send one byte of data. */
+            if (handle->transfer.dataSize > 0U)
+            {
+                base->D = *handle->transfer.data;
+                handle->transfer.data++;
+                handle->transfer.dataSize--;
+            }
+            else
+            {
+                *isDone = true;
+            }
+            break;
+
+        /* Start I2C data receive. */
+        case (uint8_t)kReceiveDataBeginState:
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+            base->SMB |= I2C_SMB_FACK_MASK;
+#endif
+
+            base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+
+            if (handle->transfer.dataSize == 1U)
+            {
+                /* Issue NACK on read. */
+                base->C1 |= I2C_C1_TXAK_MASK;
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+                base->SMB &= ~(uint8_t)I2C_SMB_FACK_MASK;
+#endif
+            }
+
+            /* Next state, receive data. */
+            handle->state = (uint8_t)kReceiveDataState;
+            break;
+
+        /* Receive I2C data. */
+        case (uint8_t)kReceiveDataState:
+            /* Receive one byte of data. */
+            if (0U != (handle->transfer.dataSize--))
+            {
+                if (handle->transfer.dataSize == 0U)
+                {
+                    *isDone = true;
+
+                    /* Send stop if kI2C_TransferNoStop is not asserted. */
+                    if (0U == (handle->transfer.flags & (uint32_t)kI2C_TransferNoStopFlag))
+                    {
+                        result = I2C_MasterStop(base);
+                    }
+                    else
+                    {
+                        base->C1 |= I2C_C1_TX_MASK;
+                    }
+                }
+
+                /* Read the data byte into the transfer buffer. */
+                tmpdata                = base->D;
+                *handle->transfer.data = tmpdata;
+                handle->transfer.data++;
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+                if (handle->transfer.dataSize != 0U)
+                {
+                    I2C_MasterAckByte(base, &dummy);
+                }
+#endif
+                if (handle->transfer.dataSize == 1U)
+                {
+                    /* Issue NACK on read. */
+                    base->C1 |= I2C_C1_TXAK_MASK;
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+                    base->SMB &= ~(uint8_t)I2C_SMB_FACK_MASK;
+#endif
+                }
+            }
+
+            break;
+
+        default:
+            /* Add this to fix MISRA C2012 rule 16.4 issue: Empty default. */
+            assert(false);
+            break;
+    }
+
+    return result;
+}
+
+static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle)
+{
+    uint8_t tmpS  = base->S;
+    uint8_t tmpC1 = base->C1;
+
+    /* Check if master interrupt. */
+    if ((0U != (tmpC1 & I2C_C1_MST_MASK)) || (0U != (tmpS & (uint8_t)kI2C_ArbitrationLostFlag)))
+    {
+        s_i2cMasterIsr(base, handle);
+    }
+    else
+    {
+        s_i2cSlaveIsr(base, handle);
+    }
+    __DSB();
+}
+
+/*!
+ * brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
+ * and configure the I2C with master configuration.
+ *
+ * note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can be custom filled
+ * or it can be set with default values by using the I2C_MasterGetDefaultConfig().
+ * After calling this API, the master is ready to transfer.
+ * This is an example.
+ * code
+ * i2c_master_config_t config = {
+ * .enableMaster = true,
+ * .enableStopHold = false,
+ * .highDrive = false,
+ * .baudRate_Bps = 100000,
+ * .glitchFilterWidth = 0
+ * };
+ * I2C_MasterInit(I2C0, &config, 12000000U);
+ * endcode
+ *
+ * param base I2C base pointer
+ * param masterConfig A pointer to the master configuration structure
+ * param srcClock_Hz I2C peripheral clock frequency in Hz
+ */
+void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz)
+{
+    assert(NULL != masterConfig);
+    assert(0U != srcClock_Hz);
+
+    /* Temporary register for filter read. */
+    uint8_t fltReg;
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    uint8_t s2Reg;
+#endif
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Enable I2C clock. */
+    CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F  = 0;
+    base->C1 = 0;
+    base->S  = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
+
+    /* Disable I2C prior to configuring it. */
+    base->C1 &= ~(uint8_t)(I2C_C1_IICEN_MASK);
+
+    /* Clear all flags. */
+    I2C_MasterClearStatusFlags(base, (uint32_t)kClearFlags);
+
+    /* Configure baud rate. */
+    I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
+
+    /* Read out the FLT register. */
+    fltReg = base->FLT;
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
+    /* Configure the stop / hold enable. */
+    fltReg &= ~(uint8_t)(I2C_FLT_SHEN_MASK);
+    fltReg |= I2C_FLT_SHEN(masterConfig->enableStopHold);
+#endif
+
+    /* Configure the glitch filter value. */
+    fltReg &= ~(uint8_t)(I2C_FLT_FLT_MASK);
+    fltReg |= I2C_FLT_FLT(masterConfig->glitchFilterWidth);
+
+    /* Write the register value back to the filter register. */
+    base->FLT = fltReg;
+
+    /* Enable the I2C peripheral based on the configuration. */
+    base->C1 = I2C_C1_IICEN(masterConfig->enableMaster);
+
+    /* Enable/Disable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    s2Reg    = (uint8_t)(base->S2 & (~I2C_S2_DFEN_MASK));
+    base->S2 = s2Reg | I2C_S2_DFEN(masterConfig->enableDoubleBuffering);
+#endif
+}
+
+/*!
+ * brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
+ * The I2C master module can't work unless the I2C_MasterInit is called.
+ * param base I2C base pointer
+ */
+void I2C_MasterDeinit(I2C_Type *base)
+{
+    /* Disable I2C module. */
+    I2C_Enable(base, false);
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Disable I2C clock. */
+    CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+/*!
+ * brief  Sets the I2C master configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
+ * Use the initialized structure unchanged in the I2C_MasterConfigure() or modify
+ * the structure before calling the I2C_MasterConfigure().
+ * This is an example.
+ * code
+ * i2c_master_config_t config;
+ * I2C_MasterGetDefaultConfig(&config);
+ * endcode
+ * param masterConfig A pointer to the master configuration structure.
+ */
+void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
+{
+    assert(NULL != masterConfig);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    /* Default baud rate at 100kbps. */
+    masterConfig->baudRate_Bps = 100000U;
+
+/* Default stop hold enable is disabled. */
+#if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
+    masterConfig->enableStopHold = false;
+#endif
+
+    /* Default glitch filter value is no filter. */
+    masterConfig->glitchFilterWidth = 0U;
+
+/* Default enable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    masterConfig->enableDoubleBuffering = true;
+#endif
+
+    /* Enable the I2C peripheral. */
+    masterConfig->enableMaster = true;
+}
+
+/*!
+ * brief Enables I2C interrupt requests.
+ *
+ * param base I2C base pointer
+ * param mask interrupt source
+ *     The parameter can be combination of the following source if defined:
+ *     arg kI2C_GlobalInterruptEnable
+ *     arg kI2C_StopDetectInterruptEnable/kI2C_StartDetectInterruptEnable
+ *     arg kI2C_SdaTimeoutInterruptEnable
+ */
+void I2C_EnableInterrupts(I2C_Type *base, uint32_t mask)
+{
+#ifdef I2C_HAS_STOP_DETECT
+    uint8_t fltReg;
+#endif
+
+    if (0U != (mask & (uint32_t)kI2C_GlobalInterruptEnable))
+    {
+        base->C1 |= I2C_C1_IICIE_MASK;
+    }
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    if (0U != (mask & (uint32_t)kI2C_StopDetectInterruptEnable))
+    {
+        fltReg = base->FLT;
+
+        /* Keep STOPF flag. */
+        fltReg &= ~I2C_FLT_STOPF_MASK;
+
+        /* Stop detect enable. */
+        fltReg |= I2C_FLT_STOPIE_MASK;
+        base->FLT = fltReg;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    if (0U != (mask & (uint32_t)kI2C_StartStopDetectInterruptEnable))
+    {
+        fltReg = base->FLT;
+
+        /* Keep STARTF and STOPF flags. */
+        fltReg &= ~(uint8_t)(I2C_FLT_STOPF_MASK | I2C_FLT_STARTF_MASK);
+
+        /* Start and stop detect enable. */
+        fltReg |= I2C_FLT_SSIE_MASK;
+        base->FLT = fltReg;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+}
+
+/*!
+ * brief Disables I2C interrupt requests.
+ *
+ * param base I2C base pointer
+ * param mask interrupt source
+ *     The parameter can be combination of the following source if defined:
+ *     arg kI2C_GlobalInterruptEnable
+ *     arg kI2C_StopDetectInterruptEnable/kI2C_StartDetectInterruptEnable
+ *     arg kI2C_SdaTimeoutInterruptEnable
+ */
+void I2C_DisableInterrupts(I2C_Type *base, uint32_t mask)
+{
+    if (0U != (mask & (uint32_t)kI2C_GlobalInterruptEnable))
+    {
+        base->C1 &= ~(uint8_t)I2C_C1_IICIE_MASK;
+    }
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    if (0U != (mask & (uint32_t)kI2C_StopDetectInterruptEnable))
+    {
+        base->FLT &= ~(I2C_FLT_STOPIE_MASK | I2C_FLT_STOPF_MASK);
+    }
+#endif /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    if (0U != (mask & (uint32_t)kI2C_StartStopDetectInterruptEnable))
+    {
+        base->FLT &= ~(uint8_t)(I2C_FLT_SSIE_MASK | I2C_FLT_STOPF_MASK | I2C_FLT_STARTF_MASK);
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+}
+
+/*!
+ * brief Sets the I2C master transfer baud rate.
+ *
+ * param base I2C base pointer
+ * param baudRate_Bps the baud rate value in bps
+ * param srcClock_Hz Source clock
+ */
+void I2C_MasterSetBaudRate(I2C_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedRate;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult  = 0u;
+    uint32_t bestIcr   = 0u;
+    uint32_t u32flag   = 1u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    for (mult = 0u; mult <= 2u; ++mult)
+    {
+        if (bestError == 0u)
+        {
+            break;
+        }
+
+        multiplier = u32flag << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(uint16_t); ++i)
+        {
+            computedRate = srcClock_Hz / (multiplier * s_i2cDividerTable[i]);
+            absError     = baudRate_Bps > computedRate ? (baudRate_Bps - computedRate) : (computedRate - baudRate_Bps);
+
+            if (absError < bestError)
+            {
+                bestMult  = mult;
+                bestIcr   = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0u)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+    g_baudrate = baudRate_Bps;
+#endif
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
+}
+
+/*!
+ * brief Sends a START on the I2C bus.
+ *
+ * This function is used to initiate a new master mode transfer by sending the START signal.
+ * The slave address is sent following the I2C START signal.
+ *
+ * param base I2C peripheral base pointer
+ * param address 7-bit slave device address.
+ * param direction Master transfer directions(transmit/receive).
+ * retval kStatus_Success Successfully send the start signal.
+ * retval kStatus_I2C_Busy Current bus is busy.
+ */
+status_t I2C_MasterStart(I2C_Type *base, uint8_t address, i2c_direction_t direction)
+{
+    status_t result      = kStatus_Success;
+    uint32_t statusFlags = I2C_MasterGetStatusFlags(base);
+
+    /* Return an error if the bus is already in use. */
+    if (0U != (statusFlags & (uint32_t)kI2C_BusBusyFlag))
+    {
+        result = kStatus_I2C_Busy;
+    }
+    else
+    {
+        /* Send the START signal. */
+        base->C1 |= I2C_C1_MST_MASK | I2C_C1_TX_MASK;
+
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING
+#if I2C_RETRY_TIMES
+        uint32_t waitTimes = I2C_RETRY_TIMES;
+        while ((0U == (base->S2 & I2C_S2_EMPTY_MASK)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        while (0U == (base->S2 & I2C_S2_EMPTY_MASK))
+        {
+        }
+#endif
+#endif /* FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING */
+
+        base->D = (uint8_t)(((uint32_t)address) << 1U | ((direction == kI2C_Read) ? 1U : 0U));
+    }
+
+    return result;
+}
+
+/*!
+ * brief Sends a REPEATED START on the I2C bus.
+ *
+ * param base I2C peripheral base pointer
+ * param address 7-bit slave device address.
+ * param direction Master transfer directions(transmit/receive).
+ * retval kStatus_Success Successfully send the start signal.
+ * retval kStatus_I2C_Busy Current bus is busy but not occupied by current I2C master.
+ */
+status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction)
+{
+    status_t result = kStatus_Success;
+    uint8_t savedMult;
+    uint32_t statusFlags = I2C_MasterGetStatusFlags(base);
+    uint8_t timeDelay    = 6;
+
+    /* Return an error if the bus is already in use, but not by us. */
+    if ((0U == (base->C1 & I2C_C1_MST_MASK)) && (0U != (statusFlags & (uint32_t)kI2C_BusBusyFlag)))
+    {
+        result = kStatus_I2C_Busy;
+    }
+    else
+    {
+        savedMult = base->F;
+        base->F   = savedMult & (~(uint8_t)I2C_F_MULT_MASK);
+
+        /* We are already in a transfer, so send a repeated start. */
+        base->C1 |= I2C_C1_RSTA_MASK | I2C_C1_TX_MASK;
+
+        /* Restore the multiplier factor. */
+        base->F = savedMult;
+
+        /* Add some delay to wait the Re-Start signal. */
+        while (0U != (timeDelay--))
+        {
+            __NOP();
+        }
+
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING
+#if I2C_RETRY_TIMES
+        uint32_t waitTimes = I2C_RETRY_TIMES;
+        while ((0U == (base->S2 & I2C_S2_EMPTY_MASK)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        while (0U == (base->S2 & I2C_S2_EMPTY_MASK))
+        {
+        }
+#endif
+#endif /* FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING */
+
+        base->D = (uint8_t)(((uint32_t)address) << 1U | ((direction == kI2C_Read) ? 1U : 0U));
+    }
+
+    return result;
+}
+
+/*!
+ * brief Sends a STOP signal on the I2C bus.
+ *
+ * retval kStatus_Success Successfully send the stop signal.
+ * retval kStatus_I2C_Timeout Send stop signal failed, timeout.
+ */
+status_t I2C_MasterStop(I2C_Type *base)
+{
+    status_t result = kStatus_Success;
+
+    /* Issue the STOP command on the bus. */
+    base->C1 &= ~(uint8_t)(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+    /* Wait until bus not busy. */
+    while ((0U != (base->S & (uint8_t)kI2C_BusBusyFlag)) && (0U != --waitTimes))
+    {
+    }
+
+    if (0U == waitTimes)
+    {
+        result = kStatus_I2C_Timeout;
+    }
+#else
+    /* Wait until data transfer complete. */
+    while (0U != (base->S & (uint8_t)kI2C_BusBusyFlag))
+    {
+    }
+#endif
+
+    return result;
+}
+
+/*!
+ * brief Gets the I2C status flags.
+ *
+ * param base I2C base pointer
+ * return status flag, use status flag to AND #_i2c_flags to get the related status.
+ */
+uint32_t I2C_MasterGetStatusFlags(I2C_Type *base)
+{
+    uint32_t statusFlags = base->S;
+
+#ifdef I2C_HAS_STOP_DETECT
+    /* Look up the STOPF bit from the filter register. */
+    if (0U != (base->FLT & I2C_FLT_STOPF_MASK))
+    {
+        statusFlags |= (uint32_t)kI2C_StopDetectFlag;
+    }
+#endif
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Look up the STARTF bit from the filter register. */
+    if (0U != (base->FLT & I2C_FLT_STARTF_MASK))
+    {
+        statusFlags |= (uint32_t)kI2C_StartDetectFlag;
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+    return statusFlags;
+}
+
+/*!
+ * brief Performs a polling send transaction on the I2C bus.
+ *
+ * param base  The I2C peripheral base pointer.
+ * param txBuff The pointer to the data to be transferred.
+ * param txSize The length in bytes of the data to be transferred.
+ * param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+ *  to issue a stop and kI2C_TransferNoStop to not send a stop.
+ * retval kStatus_Success Successfully complete the data transmission.
+ * retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags)
+{
+    status_t result     = kStatus_Success;
+    uint8_t statusFlags = 0;
+
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+    /* Wait until the data register is ready for transmit. */
+    while ((0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag)) && (0U != --waitTimes))
+    {
+    }
+    if (0U == waitTimes)
+    {
+        return kStatus_I2C_Timeout;
+    }
+#else
+    /* Wait until the data register is ready for transmit. */
+    while (0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag))
+    {
+    }
+#endif
+
+    /* Clear the IICIF flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+
+    /* Setup the I2C peripheral to transmit data. */
+    base->C1 |= I2C_C1_TX_MASK;
+
+    while (0U != (txSize--))
+    {
+        /* Send a byte of data. */
+        base->D = *txBuff++;
+
+#if I2C_RETRY_TIMES
+        waitTimes = I2C_RETRY_TIMES;
+        /* Wait until data transfer complete. */
+        while ((0U == (base->S & (uint8_t)kI2C_IntPendingFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        /* Wait until data transfer complete. */
+        while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+        {
+        }
+#endif
+        statusFlags = base->S;
+
+        /* Clear the IICIF flag. */
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        /* Check if arbitration lost or no acknowledgement (NAK), return failure status. */
+        if (0U != (statusFlags & (uint8_t)kI2C_ArbitrationLostFlag))
+        {
+            base->S = (uint8_t)kI2C_ArbitrationLostFlag;
+            result  = kStatus_I2C_ArbitrationLost;
+        }
+
+        if ((0U != (statusFlags & (uint8_t)kI2C_ReceiveNakFlag)) && (0U != txSize))
+        {
+            base->S = (uint8_t)kI2C_ReceiveNakFlag;
+            result  = kStatus_I2C_Nak;
+        }
+
+        if (result != kStatus_Success)
+        {
+            /* Breaking out of the send loop. */
+            break;
+        }
+    }
+
+    if (((result == kStatus_Success) && (0U == (flags & (uint32_t)kI2C_TransferNoStopFlag))) ||
+        (result == kStatus_I2C_Nak))
+    {
+        /* Clear the IICIF flag. */
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        /* Send stop. */
+        result = I2C_MasterStop(base);
+    }
+
+    return result;
+}
+
+/*!
+ * brief Performs a polling receive transaction on the I2C bus.
+ *
+ * note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
+ * Without stopping the bus prior for the final read, the bus issues another read, resulting
+ * in garbage data being read into the data register.
+ *
+ * param base I2C peripheral base pointer.
+ * param rxBuff The pointer to the data to store the received data.
+ * param rxSize The length in bytes of the data to be received.
+ * param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+ *  to issue a stop and kI2C_TransferNoStop to not send a stop.
+ * retval kStatus_Success Successfully complete the data transmission.
+ * retval kStatus_I2C_Timeout Send stop signal failed, timeout.
+ */
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags)
+{
+    status_t result        = kStatus_Success;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+    /* Wait until the data register is ready for transmit. */
+    while ((0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag)) && (0U != --waitTimes))
+    {
+    }
+    if (0U == waitTimes)
+    {
+        return kStatus_I2C_Timeout;
+    }
+#else
+    /* Wait until the data register is ready for transmit. */
+    while (0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag))
+    {
+    }
+#endif
+
+    /* Clear the IICIF flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+    base->SMB |= I2C_SMB_FACK_MASK;
+#endif
+
+    /* Setup the I2C peripheral to receive data. */
+    base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+    /* Do dummy read. */
+    dummy = base->D;
+
+    if (rxSize == 1U)
+    {
+        /* Issue NACK on read. */
+        base->C1 |= I2C_C1_TXAK_MASK;
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+        base->SMB &= ~(uint8_t)I2C_SMB_FACK_MASK;
+#endif
+    }
+
+    while (0U != (rxSize--))
+    {
+#if I2C_RETRY_TIMES
+        waitTimes = I2C_RETRY_TIMES;
+        /* Wait until data transfer complete. */
+        while ((0U == (base->S & (uint8_t)kI2C_IntPendingFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        /* Wait until data transfer complete. */
+        while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+        {
+        }
+#endif
+
+        if (rxSize == 0U)
+        {
+            if (0U == (flags & (uint32_t)kI2C_TransferNoStopFlag))
+            {
+                /* Issue STOP command before reading last byte. */
+                result = I2C_MasterStop(base);
+            }
+            else
+            {
+                /* Change direction to Tx to avoid extra clocks. */
+                base->C1 |= I2C_C1_TX_MASK;
+            }
+        }
+
+        /* Clear the IICIF flag. */
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        /* Read from the data register. */
+        *rxBuff++ = base->D;
+
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+        if (rxSize != 0U)
+        {
+            I2C_MasterAckByte(base, &dummy);
+        }
+#endif
+
+        if (rxSize == 1U)
+        {
+            base->C1 |= I2C_C1_TXAK_MASK;
+#if defined(I2C_MASTER_FACK_CONTROL) && I2C_MASTER_FACK_CONTROL
+            /* Issue NACK on read. */
+            base->SMB &= ~(uint8_t)I2C_SMB_FACK_MASK;
+#endif
+        }
+    }
+
+    return result;
+}
+
+/*!
+ * brief Performs a master polling transfer on the I2C bus.
+ *
+ * note The API does not return until the transfer succeeds or fails due
+ * to arbitration lost or receiving a NAK.
+ *
+ * param base I2C peripheral base address.
+ * param xfer Pointer to the transfer structure.
+ * retval kStatus_Success Successfully complete the data transmission.
+ * retval kStatus_I2C_Busy Previous transmission still not finished.
+ * retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    i2c_direction_t direction = xfer->direction;
+    status_t result           = kStatus_Success;
+
+    /* Clear all status before transfer. */
+    I2C_MasterClearStatusFlags(base, (uint32_t)kClearFlags);
+
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+    /* Wait until the data register is ready for transmit. */
+    while ((0U == (base->S & kI2C_TransferCompleteFlag)) && (0U != --waitTimes))
+    {
+    }
+    if (0U == waitTimes)
+    {
+        return kStatus_I2C_Timeout;
+    }
+#else
+    /* Wait until the data register is ready for transmit. */
+    while (0U == (base->S & (uint8_t)kI2C_TransferCompleteFlag))
+    {
+    }
+#endif
+
+    /* Change to send write address when it's a read operation with command. */
+    if ((xfer->subaddressSize > 0U) && (xfer->direction == kI2C_Read))
+    {
+        direction = kI2C_Write;
+    }
+
+    /* Handle no start option, only support write with no start signal. */
+    if (0U != (xfer->flags & (uint32_t)kI2C_TransferNoStartFlag))
+    {
+        if (direction == kI2C_Read)
+        {
+            return kStatus_InvalidArgument;
+        }
+    }
+    /* If repeated start is requested, send repeated start. */
+    else if (0U != (xfer->flags & (uint32_t)kI2C_TransferRepeatedStartFlag))
+    {
+        result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, direction);
+    }
+    else /* For normal transfer, send start. */
+    {
+        result = I2C_MasterStart(base, xfer->slaveAddress, direction);
+    }
+
+    if (0U == (xfer->flags & (uint32_t)kI2C_TransferNoStartFlag))
+    {
+        /* Return if error. */
+        if (kStatus_Success != result)
+        {
+            return result;
+        }
+
+#if I2C_RETRY_TIMES
+        waitTimes = I2C_RETRY_TIMES;
+        /* Wait until data transfer complete. */
+        while ((0U == (base->S & kI2C_IntPendingFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        /* Wait until data transfer complete. */
+        while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+        {
+        }
+#endif
+        /* Check if there's transfer error. */
+        result = I2C_CheckAndClearError(base, base->S);
+
+        /* Return if error. */
+        if (kStatus_Success != result)
+        {
+            if (result == kStatus_I2C_Nak)
+            {
+                result = kStatus_I2C_Addr_Nak;
+
+                (void)I2C_MasterStop(base);
+            }
+
+            return result;
+        }
+    }
+
+    /* Send subaddress. */
+    if (0U != (xfer->subaddressSize))
+    {
+        do
+        {
+            /* Clear interrupt pending flag. */
+            base->S = (uint8_t)kI2C_IntPendingFlag;
+
+            xfer->subaddressSize--;
+            base->D = (uint8_t)((xfer->subaddress) >> (8U * xfer->subaddressSize));
+
+#if I2C_RETRY_TIMES
+            waitTimes = I2C_RETRY_TIMES;
+            /* Wait until data transfer complete. */
+            while ((0U == (base->S & kI2C_IntPendingFlag)) && (0U != --waitTimes))
+            {
+            }
+            if (0U == waitTimes)
+            {
+                return kStatus_I2C_Timeout;
+            }
+#else
+            /* Wait until data transfer complete. */
+            while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+            {
+            }
+#endif
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (0 != result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    (void)I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+        } while (xfer->subaddressSize > 0u);
+
+        if (xfer->direction == kI2C_Read)
+        {
+            /* Clear pending flag. */
+            base->S = (uint8_t)kI2C_IntPendingFlag;
+
+            /* Send repeated start and slave address. */
+            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
+
+            /* Return if error. */
+            if (kStatus_Success != result)
+            {
+                return result;
+            }
+
+#if I2C_RETRY_TIMES
+            waitTimes = I2C_RETRY_TIMES;
+            /* Wait until data transfer complete. */
+            while ((0U == (base->S & kI2C_IntPendingFlag)) && (0U != --waitTimes))
+            {
+            }
+            if (0U == waitTimes)
+            {
+                return kStatus_I2C_Timeout;
+            }
+#else
+            /* Wait until data transfer complete. */
+            while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+            {
+            }
+#endif
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (kStatus_Success != result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    result = kStatus_I2C_Addr_Nak;
+
+                    (void)I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /* Transmit data. */
+    if (xfer->direction == kI2C_Write)
+    {
+        if (xfer->dataSize > 0U)
+        {
+            uint8_t *tmpData   = xfer->data;
+            size_t tmpDataSize = xfer->dataSize;
+            uint32_t tmpFlags  = xfer->flags;
+            /* Send Data. */
+            result = I2C_MasterWriteBlocking(base, tmpData, tmpDataSize, tmpFlags);
+        }
+        else if (0U == (xfer->flags & (uint32_t)kI2C_TransferNoStopFlag))
+        {
+            /* Send stop. */
+            result = I2C_MasterStop(base);
+        }
+        else
+        {
+            /* Add this to fix MISRA C2012 rule15.7 issue: Empty else without comment. */
+        }
+    }
+
+    /* Receive Data. */
+    if ((xfer->dataSize > 0u) && (xfer->direction == kI2C_Read))
+    {
+        uint8_t *tmpData   = xfer->data;
+        size_t tmpDataSize = xfer->dataSize;
+        uint32_t tmpFlags  = xfer->flags;
+
+        result = I2C_MasterReadBlocking(base, tmpData, tmpDataSize, tmpFlags);
+    }
+
+    return result;
+}
+
+/*!
+ * brief Initializes the I2C handle which is used in transactional functions.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_master_handle_t structure to store the transfer state.
+ * param callback pointer to user callback function.
+ * param userData user parameter passed to the callback function.
+ */
+void I2C_MasterTransferCreateHandle(I2C_Type *base,
+                                    i2c_master_handle_t *handle,
+                                    i2c_master_transfer_callback_t callback,
+                                    void *userData)
+{
+    assert(NULL != handle);
+
+    uint32_t instance = I2C_GetInstance(base);
+
+    /* Zero handle. */
+    (void)memset(handle, 0, sizeof(*handle));
+
+    /* Set callback and userData. */
+    handle->completionCallback = callback;
+    handle->userData           = userData;
+
+    /* Save the context in global variables to support the double weak mechanism. */
+    s_i2cHandle[instance] = handle;
+
+    /* Save master interrupt handler. */
+    s_i2cMasterIsr = I2C_MasterTransferHandleIRQ;
+
+    /* Enable NVIC interrupt. */
+    (void)EnableIRQ(s_i2cIrqs[instance]);
+}
+
+/*!
+ * brief Performs a master interrupt non-blocking transfer on the I2C bus.
+ *
+ * note Calling the API returns immediately after transfer initiates. The user needs
+ * to call I2C_MasterGetTransferCount to poll the transfer status to check whether
+ * the transfer is finished. If the return status is not kStatus_I2C_Busy, the transfer
+ * is finished.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * param xfer pointer to i2c_master_transfer_t structure.
+ * retval kStatus_Success Successfully start the data transmission.
+ * retval kStatus_I2C_Busy Previous transmission still not finished.
+ * retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ */
+status_t I2C_MasterTransferNonBlocking(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
+{
+    assert(NULL != handle);
+    assert(NULL != xfer);
+
+    status_t result = kStatus_Success;
+
+    /* Check if the I2C bus is idle - if not return busy status. */
+    if (handle->state != (uint8_t)kIdleState)
+    {
+        result = kStatus_I2C_Busy;
+    }
+    else
+    {
+        /* Start up the master transfer state machine. */
+        result = I2C_InitTransferStateMachine(base, handle, xfer);
+
+        if (result == kStatus_Success)
+        {
+            /* Enable the I2C interrupts. */
+            I2C_EnableInterrupts(base, (uint32_t)kI2C_GlobalInterruptEnable);
+        }
+    }
+
+    return result;
+}
+
+/*!
+ * brief Aborts an interrupt non-blocking transfer early.
+ *
+ * note This API can be called at any time when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ * retval kStatus_I2C_Timeout Timeout during polling flag.
+ * retval kStatus_Success Successfully abort the transfer.
+ */
+status_t I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle)
+{
+    assert(NULL != handle);
+
+    volatile uint8_t dummy = 0;
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+#endif
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    /* Disable interrupt. */
+    I2C_DisableInterrupts(base, (uint32_t)kI2C_GlobalInterruptEnable);
+
+    /* Reset the state to idle. */
+    handle->state = (uint8_t)kIdleState;
+
+    /* If the bus is already in use, but not by us */
+    if (0U == (base->C1 & I2C_C1_MST_MASK))
+    {
+        return kStatus_I2C_Busy;
+    }
+
+    /* Send STOP signal. */
+    if (handle->transfer.direction == kI2C_Read)
+    {
+        base->C1 |= I2C_C1_TXAK_MASK;
+
+#if I2C_RETRY_TIMES
+        /* Wait until data transfer complete. */
+        while ((0U == (base->S & (uint8_t)kI2C_IntPendingFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        /* Wait until data transfer complete. */
+        while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+        {
+        }
+#endif
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        base->C1 &= ~(uint8_t)(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+        dummy = base->D;
+    }
+    else
+    {
+#if I2C_RETRY_TIMES
+        /* Wait until data transfer complete. */
+        while ((0U == (base->S & (uint8_t)kI2C_IntPendingFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        /* Wait until data transfer complete. */
+        while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+        {
+        }
+#endif
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+        base->C1 &= ~(uint8_t)(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+    }
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Gets the master transfer status during a interrupt non-blocking transfer.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * param count Number of bytes transferred so far by the non-blocking transaction.
+ * retval kStatus_InvalidArgument count is Invalid.
+ * retval kStatus_Success Successfully return the count.
+ */
+status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count)
+{
+    assert(NULL != handle);
+
+    if (NULL == count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    *count = handle->transferSize - handle->transfer.dataSize;
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Master interrupt handler.
+ *
+ * param base I2C base pointer.
+ * param i2cHandle pointer to i2c_master_handle_t structure.
+ */
+void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
+{
+    assert(NULL != i2cHandle);
+
+    i2c_master_handle_t *handle = (i2c_master_handle_t *)i2cHandle;
+    status_t result             = kStatus_Success;
+    bool isDone;
+
+    /* Clear the interrupt flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+
+    /* Check transfer complete flag. */
+    result = I2C_MasterTransferRunStateMachine(base, handle, &isDone);
+
+    if ((true == isDone) || (0 != result))
+    {
+        /* Send stop command if transfer done or received Nak. */
+        if ((0U == (handle->transfer.flags & (uint32_t)kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak) ||
+            (result == kStatus_I2C_Addr_Nak))
+        {
+            /* Ensure stop command is a need. */
+            if (0U != (base->C1 & I2C_C1_MST_MASK))
+            {
+                if (I2C_MasterStop(base) != kStatus_Success)
+                {
+                    result = kStatus_I2C_Timeout;
+                }
+            }
+        }
+
+        /* Restore handle to idle state. */
+        handle->state = (uint8_t)kIdleState;
+
+        /* Disable interrupt. */
+        I2C_DisableInterrupts(base, (uint32_t)kI2C_GlobalInterruptEnable);
+
+        /* Call the callback function after the function has completed. */
+        if (NULL != (handle->completionCallback))
+        {
+            handle->completionCallback(base, handle, result, handle->userData);
+        }
+    }
+}
+
+/*!
+ * brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
+ * and initialize the I2C with the slave configuration.
+ *
+ * note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can partly be set
+ * with default values by I2C_SlaveGetDefaultConfig() or it can be custom filled by the user.
+ * This is an example.
+ * code
+ * i2c_slave_config_t config = {
+ * .enableSlave = true,
+ * .enableGeneralCall = false,
+ * .addressingMode = kI2C_Address7bit,
+ * .slaveAddress = 0x1DU,
+ * .enableWakeUp = false,
+ * .enablehighDrive = false,
+ * .enableBaudRateCtl = false,
+ * .sclStopHoldTime_ns = 4000
+ * };
+ * I2C_SlaveInit(I2C0, &config, 12000000U);
+ * endcode
+ *
+ * param base I2C base pointer
+ * param slaveConfig A pointer to the slave configuration structure
+ * param srcClock_Hz I2C peripheral clock frequency in Hz
+ */
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz)
+{
+    assert(NULL != slaveConfig);
+
+    uint8_t tmpReg;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F  = 0;
+    base->C1 = 0;
+    base->S  = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
+
+    /* Configure addressing mode. */
+    switch (slaveConfig->addressingMode)
+    {
+        case kI2C_Address7bit:
+            base->A1 = (uint8_t)(((uint32_t)(slaveConfig->slaveAddress)) << 1U);
+            break;
+
+        case kI2C_RangeMatch:
+            assert(slaveConfig->slaveAddress < slaveConfig->upperAddress);
+            base->A1 = (uint8_t)(((uint32_t)(slaveConfig->slaveAddress)) << 1U);
+            base->RA = (uint8_t)(((uint32_t)(slaveConfig->upperAddress)) << 1U);
+            base->C2 |= I2C_C2_RMEN_MASK;
+            break;
+
+        default:
+            /* All the cases have been listed above, the default clause should not be reached. */
+            assert(false);
+            break;
+    }
+
+    /* Configure low power wake up feature. */
+    tmpReg = base->C1;
+    tmpReg &= ~(uint8_t)I2C_C1_WUEN_MASK;
+    base->C1 = tmpReg | I2C_C1_WUEN(slaveConfig->enableWakeUp) | I2C_C1_IICEN(slaveConfig->enableSlave);
+
+    /* Configure general call & baud rate control. */
+    tmpReg = base->C2;
+    tmpReg &= ~(uint8_t)(I2C_C2_SBRC_MASK | I2C_C2_GCAEN_MASK);
+    tmpReg |= I2C_C2_SBRC(slaveConfig->enableBaudRateCtl) | I2C_C2_GCAEN(slaveConfig->enableGeneralCall);
+    base->C2 = tmpReg;
+
+/* Enable/Disable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    tmpReg   = (uint8_t)(base->S2 & (~I2C_S2_DFEN_MASK));
+    base->S2 = tmpReg | I2C_S2_DFEN(slaveConfig->enableDoubleBuffering);
+#endif
+
+    /* Set hold time. */
+    I2C_SetHoldTime(base, slaveConfig->sclStopHoldTime_ns, srcClock_Hz);
+}
+
+/*!
+ * brief De-initializes the I2C slave peripheral. Calling this API gates the I2C clock.
+ * The I2C slave module can't work unless the I2C_SlaveInit is called to enable the clock.
+ * param base I2C base pointer
+ */
+void I2C_SlaveDeinit(I2C_Type *base)
+{
+    /* Disable I2C module. */
+    I2C_Enable(base, false);
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Disable I2C clock. */
+    CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+/*!
+ * brief  Sets the I2C slave configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_SlaveConfigure().
+ * Modify fields of the structure before calling the I2C_SlaveConfigure().
+ * This is an example.
+ * code
+ * i2c_slave_config_t config;
+ * I2C_SlaveGetDefaultConfig(&config);
+ * endcode
+ * param slaveConfig A pointer to the slave configuration structure.
+ */
+void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
+{
+    assert(NULL != slaveConfig);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    /* By default slave is addressed with 7-bit address. */
+    slaveConfig->addressingMode = kI2C_Address7bit;
+
+    /* General call mode is disabled by default. */
+    slaveConfig->enableGeneralCall = false;
+
+    /* Slave address match waking up MCU from low power mode is disabled. */
+    slaveConfig->enableWakeUp = false;
+
+    /* Independent slave mode baud rate at maximum frequency is disabled. */
+    slaveConfig->enableBaudRateCtl = false;
+
+/* Default enable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    slaveConfig->enableDoubleBuffering = true;
+#endif
+
+    /* Set default SCL stop hold time to 4us which is minimum requirement in I2C spec. */
+    slaveConfig->sclStopHoldTime_ns = 4000;
+
+    /* Enable the I2C peripheral. */
+    slaveConfig->enableSlave = true;
+}
+
+/*!
+ * brief Performs a polling send transaction on the I2C bus.
+ *
+ * param base  The I2C peripheral base pointer.
+ * param txBuff The pointer to the data to be transferred.
+ * param txSize The length in bytes of the data to be transferred.
+ * retval kStatus_Success Successfully complete the data transmission.
+ * retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+{
+    status_t result        = kStatus_Success;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Check start flag. */
+    while (0U == (base->FLT & I2C_FLT_STARTF_MASK))
+    {
+    }
+    /* Clear STARTF flag. */
+    base->FLT |= I2C_FLT_STARTF_MASK;
+    /* Clear the IICIF flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+    /* Wait until data transfer complete. */
+    while ((0U == (base->S & kI2C_AddressMatchFlag)) && (0U != --waitTimes))
+    {
+    }
+    if (0U == waitTimes)
+    {
+        return kStatus_I2C_Timeout;
+    }
+#else
+    /* Wait for address match flag. */
+    while (0U == (base->S & (uint8_t)kI2C_AddressMatchFlag))
+    {
+    }
+#endif
+    /* Read dummy to release bus. */
+    dummy = base->D;
+
+    result = I2C_MasterWriteBlocking(base, txBuff, txSize, (uint32_t)kI2C_TransferNoStopFlag);
+
+    /* Switch to receive mode. */
+    base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+    /* Read dummy to release bus. */
+    dummy = base->D;
+
+    return result;
+}
+
+/*!
+ * brief Performs a polling receive transaction on the I2C bus.
+ *
+ * param base I2C peripheral base pointer.
+ * param rxBuff The pointer to the data to store the received data.
+ * param rxSize The length in bytes of the data to be received.
+ * retval kStatus_Success Successfully complete data receive.
+ * retval kStatus_I2C_Timeout Wait status flag timeout.
+ */
+status_t I2C_SlaveReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+{
+    status_t result        = kStatus_Success;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+/* Wait until address match. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Check start flag. */
+    while (0U == (base->FLT & I2C_FLT_STARTF_MASK))
+    {
+    }
+    /* Clear STARTF flag. */
+    base->FLT |= I2C_FLT_STARTF_MASK;
+    /* Clear the IICIF flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+#if I2C_RETRY_TIMES
+    uint32_t waitTimes = I2C_RETRY_TIMES;
+    /* Wait for address match and int pending flag. */
+    while ((0U == (base->S & kI2C_AddressMatchFlag)) && (0U != --waitTimes))
+    {
+    }
+    if (0U == waitTimes)
+    {
+        return kStatus_I2C_Timeout;
+    }
+
+    waitTimes = I2C_RETRY_TIMES;
+    while ((0U == (base->S & kI2C_IntPendingFlag)) && (0U != --waitTimes))
+    {
+    }
+    if (0U == waitTimes)
+    {
+        return kStatus_I2C_Timeout;
+    }
+#else
+    /* Wait for address match and int pending flag. */
+    while (0U == (base->S & (uint8_t)kI2C_AddressMatchFlag))
+    {
+    }
+    while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+    {
+    }
+#endif
+
+    /* Read dummy to release bus. */
+    dummy = base->D;
+
+    /* Clear the IICIF flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+
+    /* Setup the I2C peripheral to receive data. */
+    base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK);
+
+    while (0U != (rxSize--))
+    {
+#if I2C_RETRY_TIMES
+        waitTimes = I2C_RETRY_TIMES;
+        /* Wait until data transfer complete. */
+        while ((0U == (base->S & kI2C_IntPendingFlag)) && (0U != --waitTimes))
+        {
+        }
+        if (0U == waitTimes)
+        {
+            return kStatus_I2C_Timeout;
+        }
+#else
+        /* Wait until data transfer complete. */
+        while (0U == (base->S & (uint8_t)kI2C_IntPendingFlag))
+        {
+        }
+#endif
+        /* Clear the IICIF flag. */
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        /* Read from the data register. */
+        *rxBuff++ = base->D;
+    }
+
+    return result;
+}
+
+/*!
+ * brief Initializes the I2C handle which is used in transactional functions.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_slave_handle_t structure to store the transfer state.
+ * param callback pointer to user callback function.
+ * param userData user parameter passed to the callback function.
+ */
+void I2C_SlaveTransferCreateHandle(I2C_Type *base,
+                                   i2c_slave_handle_t *handle,
+                                   i2c_slave_transfer_callback_t callback,
+                                   void *userData)
+{
+    assert(NULL != handle);
+
+    uint32_t instance = I2C_GetInstance(base);
+
+    /* Zero handle. */
+    (void)memset(handle, 0, sizeof(*handle));
+
+    /* Set callback and userData. */
+    handle->callback = callback;
+    handle->userData = userData;
+
+    /* Save the context in global variables to support the double weak mechanism. */
+    s_i2cHandle[instance] = handle;
+
+    /* Save slave interrupt handler. */
+    s_i2cSlaveIsr = I2C_SlaveTransferHandleIRQ;
+
+    /* Enable NVIC interrupt. */
+    (void)EnableIRQ(s_i2cIrqs[instance]);
+}
+
+/*!
+ * brief Starts accepting slave transfers.
+ *
+ * Call this API after calling the I2C_SlaveInit() and I2C_SlaveTransferCreateHandle() to start processing
+ * transactions driven by an I2C master. The slave monitors the I2C bus and passes events to the
+ * callback that was passed into the call to I2C_SlaveTransferCreateHandle(). The callback is always invoked
+ * from the interrupt context.
+ *
+ * The set of events received by the callback is customizable. To do so, set the a eventMask parameter to
+ * the OR'd combination of #i2c_slave_transfer_event_t enumerators for the events you wish to receive.
+ * The #kI2C_SlaveTransmitEvent and #kLPI2C_SlaveReceiveEvent events are always enabled and do not need
+ * to be included in the mask. Alternatively, pass 0 to get a default set of only the transmit and
+ * receive events that are always enabled. In addition, the #kI2C_SlaveAllEvents constant is provided as
+ * a convenient way to enable all events.
+ *
+ * param base The I2C peripheral base address.
+ * param handle Pointer to #i2c_slave_handle_t structure which stores the transfer state.
+ * param eventMask Bit mask formed by OR'ing together #i2c_slave_transfer_event_t enumerators to specify
+ *      which events to send to the callback. Other accepted values are 0 to get a default set of
+ *      only the transmit and receive events, and #kI2C_SlaveAllEvents to enable all events.
+ *
+ * retval #kStatus_Success Slave transfers were successfully started.
+ * retval #kStatus_I2C_Busy Slave transfers have already been started on this handle.
+ */
+status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle, uint32_t eventMask)
+{
+    assert(NULL != handle);
+
+    /* Check if the I2C bus is idle - if not return busy status. */
+    if (true == handle->isBusy)
+    {
+        return kStatus_I2C_Busy;
+    }
+    else
+    {
+        /* Disable LPI2C IRQ sources while we configure stuff. */
+        I2C_DisableInterrupts(base, (uint32_t)kIrqFlags);
+
+        /* Clear transfer in handle. */
+        (void)memset(&handle->transfer, 0, sizeof(handle->transfer));
+
+        /* Record that we're busy. */
+        handle->isBusy = true;
+
+        /* Set up event mask. tx and rx are always enabled. */
+        handle->eventMask = eventMask | (uint32_t)kI2C_SlaveTransmitEvent | (uint32_t)kI2C_SlaveReceiveEvent |
+                            (uint32_t)kI2C_SlaveGenaralcallEvent;
+
+        /* Clear all flags. */
+        I2C_SlaveClearStatusFlags(base, (uint32_t)kClearFlags);
+
+        /* Enable I2C internal IRQ sources. NVIC IRQ was enabled in CreateHandle() */
+        I2C_EnableInterrupts(base, (uint32_t)kIrqFlags);
+    }
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Aborts the slave transfer.
+ *
+ * note This API can be called at any time to stop slave for handling the bus events.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_slave_handle_t structure which stores the transfer state.
+ */
+void I2C_SlaveTransferAbort(I2C_Type *base, i2c_slave_handle_t *handle)
+{
+    assert(NULL != handle);
+
+    if (true == handle->isBusy)
+    {
+        /* Disable interrupts. */
+        I2C_DisableInterrupts(base, (uint32_t)kIrqFlags);
+
+        /* Reset transfer info. */
+        (void)memset(&handle->transfer, 0, sizeof(handle->transfer));
+
+        /* Reset the state to idle. */
+        handle->isBusy = false;
+    }
+}
+
+/*!
+ * brief Gets the slave transfer remaining bytes during a interrupt non-blocking transfer.
+ *
+ * param base I2C base pointer.
+ * param handle pointer to i2c_slave_handle_t structure.
+ * param count Number of bytes transferred so far by the non-blocking transaction.
+ * retval kStatus_InvalidArgument count is Invalid.
+ * retval kStatus_Success Successfully return the count.
+ */
+status_t I2C_SlaveTransferGetCount(I2C_Type *base, i2c_slave_handle_t *handle, size_t *count)
+{
+    assert(NULL != handle);
+
+    if (NULL == count)
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Catch when there is not an active transfer. */
+    if (false == handle->isBusy)
+    {
+        *count = 0;
+        return kStatus_NoTransferInProgress;
+    }
+
+    /* For an active transfer, just return the count from the handle. */
+    *count = handle->transfer.transferredCount;
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Slave interrupt handler.
+ *
+ * param base I2C base pointer.
+ * param i2cHandle pointer to i2c_slave_handle_t structure which stores the transfer state
+ */
+void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
+{
+    assert(NULL != i2cHandle);
+
+    uint16_t status;
+    bool doTransmit            = false;
+    i2c_slave_handle_t *handle = (i2c_slave_handle_t *)i2cHandle;
+    i2c_slave_transfer_t *xfer;
+    volatile uint8_t dummy = 0;
+    size_t tmpDataSize     = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+    status = (uint16_t)I2C_SlaveGetStatusFlags(base);
+    xfer   = &(handle->transfer);
+
+#ifdef I2C_HAS_STOP_DETECT
+    /* Check stop flag. */
+    if (0U != (status & (uint16_t)kI2C_StopDetectFlag))
+    {
+        I2C_MasterClearStatusFlags(base, (uint32_t)kI2C_StopDetectFlag);
+
+        /* Clear the interrupt flag. */
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        /* Call slave callback if this is the STOP of the transfer. */
+        if (true == handle->isBusy)
+        {
+            xfer->event            = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_Success;
+            handle->isBusy         = false;
+
+            if ((0U != (handle->eventMask & (uint32_t)xfer->event)) && (NULL != handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+        }
+
+        if (0U == (status & (uint16_t)kI2C_AddressMatchFlag))
+        {
+            return;
+        }
+    }
+#endif /* I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Check start flag. */
+    if (0U != (status & (uint16_t)kI2C_StartDetectFlag))
+    {
+        I2C_MasterClearStatusFlags(base, (uint32_t)kI2C_StartDetectFlag);
+
+        /* Clear the interrupt flag. */
+        base->S = (uint8_t)kI2C_IntPendingFlag;
+
+        xfer->event = kI2C_SlaveStartEvent;
+
+        if ((0U != (handle->eventMask & (uint32_t)xfer->event)) && (NULL != handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
+        }
+
+        if (0U == (status & (uint16_t)kI2C_AddressMatchFlag))
+        {
+            return;
+        }
+    }
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+    /* Clear the interrupt flag. */
+    base->S = (uint8_t)kI2C_IntPendingFlag;
+
+    /* Check NAK */
+    if (0U != (status & (uint16_t)kI2C_ReceiveNakFlag))
+    {
+        /* Set receive mode. */
+        base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+        /* Read dummy. */
+        dummy = base->D;
+
+        if (handle->transfer.dataSize != 0u)
+        {
+            xfer->event            = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_I2C_Nak;
+            handle->isBusy         = false;
+
+            if ((0U != (handle->eventMask & (uint32_t)xfer->event)) && (NULL != handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+        }
+        else
+        {
+#ifndef I2C_HAS_STOP_DETECT
+            xfer->event            = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_Success;
+            handle->isBusy         = false;
+
+            if ((0U != (handle->eventMask & (uint32_t)xfer->event)) && (NULL != handle->callback))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+#endif /* !FSL_FEATURE_I2C_HAS_START_STOP_DETECT or !FSL_FEATURE_I2C_HAS_STOP_DETECT */
+        }
+    }
+    /* Check address match. */
+    else if (0U != (status & (uint16_t)kI2C_AddressMatchFlag))
+    {
+        handle->isBusy = true;
+        xfer->event    = kI2C_SlaveAddressMatchEvent;
+
+        /* Slave transmit, master reading from slave. */
+        if (0U != (status & (uint16_t)kI2C_TransferDirectionFlag))
+        {
+            /* Change direction to send data. */
+            base->C1 |= I2C_C1_TX_MASK;
+
+            doTransmit = true;
+        }
+        else
+        {
+            /* Slave receive, master writing to slave. */
+            base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+
+            if (dummy == 0u)
+            {
+                xfer->event = kI2C_SlaveGenaralcallEvent;
+            }
+        }
+
+        if ((0U != (handle->eventMask & (uint32_t)xfer->event)) && (NULL != handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
+        }
+    }
+    /* Check transfer complete flag. */
+    else if (0U != (status & (uint16_t)kI2C_TransferCompleteFlag))
+    {
+        /* Slave transmit, master reading from slave. */
+        if (0U != (status & (uint16_t)kI2C_TransferDirectionFlag))
+        {
+            doTransmit = true;
+        }
+        else
+        {
+            tmpDataSize = xfer->dataSize;
+            /* If we're out of data, invoke callback to get more. */
+            if ((NULL == xfer->data) || (0U == tmpDataSize))
+            {
+                xfer->event = kI2C_SlaveReceiveEvent;
+
+                if (NULL != handle->callback)
+                {
+                    handle->callback(base, xfer, handle->userData);
+                }
+
+                /* Clear the transferred count now that we have a new buffer. */
+                xfer->transferredCount = 0;
+            }
+
+            /* Slave receive, master writing to slave. */
+            uint8_t data = base->D;
+
+            if (0U != (handle->transfer.dataSize))
+            {
+                /* Receive data. */
+                *handle->transfer.data++ = data;
+                handle->transfer.dataSize--;
+                xfer->transferredCount++;
+                if (0U == handle->transfer.dataSize)
+                {
+#ifndef I2C_HAS_STOP_DETECT
+                    xfer->event            = kI2C_SlaveCompletionEvent;
+                    xfer->completionStatus = kStatus_Success;
+                    handle->isBusy         = false;
+
+                    /* Proceed receive complete event. */
+                    if (((handle->eventMask & (uint32_t)xfer->event) != 0U) && (handle->callback != NULL))
+                    {
+                        handle->callback(base, xfer, handle->userData);
+                    }
+#endif /* !FSL_FEATURE_I2C_HAS_START_STOP_DETECT or !FSL_FEATURE_I2C_HAS_STOP_DETECT */
+                }
+            }
+        }
+    }
+    else
+    {
+        /* Read dummy to release bus. */
+        dummy = base->D;
+    }
+
+    /* Send data if there is the need. */
+    if (doTransmit)
+    {
+        tmpDataSize = xfer->dataSize;
+        /* If we're out of data, invoke callback to get more. */
+        if ((NULL == xfer->data) || (0U == tmpDataSize))
+        {
+            xfer->event = kI2C_SlaveTransmitEvent;
+
+            if (NULL != handle->callback)
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+
+            /* Clear the transferred count now that we have a new buffer. */
+            xfer->transferredCount = 0;
+        }
+
+        if (0U != (handle->transfer.dataSize))
+        {
+            /* Send data. */
+            base->D = *handle->transfer.data++;
+            handle->transfer.dataSize--;
+            xfer->transferredCount++;
+        }
+        else
+        {
+            /* Switch to receive mode. */
+            base->C1 &= ~(uint8_t)(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+            /* Read dummy to release bus. */
+            dummy = base->D;
+
+#ifndef I2C_HAS_STOP_DETECT
+            xfer->event            = kI2C_SlaveCompletionEvent;
+            xfer->completionStatus = kStatus_Success;
+            handle->isBusy         = false;
+
+            /* Proceed txdone event. */
+            if (((handle->eventMask & (uint32_t)xfer->event) != 0U) && (handle->callback != NULL))
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+#endif /* !FSL_FEATURE_I2C_HAS_START_STOP_DETECT or !FSL_FEATURE_I2C_HAS_STOP_DETECT */
+        }
+    }
+}
+
+#if defined(FSL_FEATURE_I2C_HAS_SHARED_IRQ0_IRQ1) && FSL_FEATURE_I2C_HAS_SHARED_IRQ0_IRQ1
+void I2C0_I2C1_DriverIRQHandler(void)
+{
+    for (uint32_t instance = 0U; instance < 2U; instance++)
+    {
+        if (s_i2cHandle[instance] != NULL)
+        {
+            I2C_TransferCommonIRQHandler(s_i2cBases[instance], s_i2cHandle[instance]);
+        }
+    }
+}
+#else
+#if defined(I2C0)
+void I2C0_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C0, s_i2cHandle[0]);
+}
+#endif
+
+#if defined(I2C1)
+void I2C1_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C1, s_i2cHandle[1]);
+}
+#endif
+#endif
+
+#if defined(I2C2)
+void I2C2_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C2, s_i2cHandle[2]);
+}
+#endif
+
+#if defined(I2C3)
+void I2C3_DriverIRQHandler(void)
+{
+    I2C_TransferCommonIRQHandler(I2C3, s_i2cHandle[3]);
+}
+#endif

--- a/drivers/fsl_i2c.h
+++ b/drivers/fsl_i2c.h
@@ -1,0 +1,805 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2020 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _FSL_I2C_H_
+#define _FSL_I2C_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup i2c_driver
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief I2C driver version 2.0.8. */
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 8))
+/*@}*/
+
+/*! @brief Retry times for waiting flag. */
+#ifndef I2C_RETRY_TIMES
+#define I2C_RETRY_TIMES 0U /* Define to zero means keep waiting until the flag is assert/deassert. */
+#endif
+
+/*! @brief Mater Fast ack control, control if master needs to manually write ack, this is used to
+low the speed of transfer for SoCs with feature FSL_FEATURE_I2C_HAS_DOUBLE_BUFFERING */
+#ifndef I2C_MASTER_FACK_CONTROL
+#define I2C_MASTER_FACK_CONTROL 0U /* Default defines to zero means master will send ack automatically. */
+#endif
+
+#if (defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT || \
+     defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT)
+#define I2C_HAS_STOP_DETECT
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT / FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+/*! @brief  I2C status return codes. */
+enum
+{
+    kStatus_I2C_Busy            = MAKE_STATUS(kStatusGroup_I2C, 0), /*!< I2C is busy with current transfer. */
+    kStatus_I2C_Idle            = MAKE_STATUS(kStatusGroup_I2C, 1), /*!< Bus is Idle. */
+    kStatus_I2C_Nak             = MAKE_STATUS(kStatusGroup_I2C, 2), /*!< NAK received during transfer. */
+    kStatus_I2C_ArbitrationLost = MAKE_STATUS(kStatusGroup_I2C, 3), /*!< Arbitration lost during transfer. */
+    kStatus_I2C_Timeout         = MAKE_STATUS(kStatusGroup_I2C, 4), /*!< Timeout polling status flags. */
+    kStatus_I2C_Addr_Nak        = MAKE_STATUS(kStatusGroup_I2C, 5), /*!< NAK received during the address probe. */
+};
+
+/*!
+ * @brief I2C peripheral flags
+ *
+ * @note These enumerations are meant to be OR'd together to form a bit mask.
+ *
+ */
+enum _i2c_flags
+{
+    kI2C_ReceiveNakFlag        = I2C_S_RXAK_MASK,  /*!< I2C receive NAK flag. */
+    kI2C_IntPendingFlag        = I2C_S_IICIF_MASK, /*!< I2C interrupt pending flag. This flag can be cleared. */
+    kI2C_TransferDirectionFlag = I2C_S_SRW_MASK,   /*!< I2C transfer direction flag. */
+    kI2C_RangeAddressMatchFlag = I2C_S_RAM_MASK,   /*!< I2C range address match flag. */
+    kI2C_ArbitrationLostFlag   = I2C_S_ARBL_MASK,  /*!< I2C arbitration lost flag. This flag can be cleared. */
+    kI2C_BusBusyFlag           = I2C_S_BUSY_MASK,  /*!< I2C bus busy flag. */
+    kI2C_AddressMatchFlag      = I2C_S_IAAS_MASK,  /*!< I2C address match flag. */
+    kI2C_TransferCompleteFlag  = I2C_S_TCF_MASK,   /*!< I2C transfer complete flag. */
+#ifdef I2C_HAS_STOP_DETECT
+    kI2C_StopDetectFlag = I2C_FLT_STOPF_MASK << 8, /*!< I2C stop detect flag. This flag can be cleared. */
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT / FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kI2C_StartDetectFlag = I2C_FLT_STARTF_MASK << 8, /*!< I2C start detect flag. This flag can be cleared. */
+#endif                                               /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+};
+
+/*! @brief I2C feature interrupt source. */
+enum _i2c_interrupt_enable
+{
+    kI2C_GlobalInterruptEnable = I2C_C1_IICIE_MASK, /*!< I2C global interrupt. */
+
+#if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    kI2C_StopDetectInterruptEnable = I2C_FLT_STOPIE_MASK, /*!< I2C stop detect interrupt. */
+#endif                                                    /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kI2C_StartStopDetectInterruptEnable = I2C_FLT_SSIE_MASK, /*!< I2C start&stop detect interrupt. */
+#endif                                                       /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+};
+
+/*! @brief The direction of master and slave transfers. */
+typedef enum _i2c_direction
+{
+    kI2C_Write = 0x0U, /*!< Master transmits to the slave. */
+    kI2C_Read  = 0x1U, /*!< Master receives from the slave. */
+} i2c_direction_t;
+
+/*! @brief Addressing mode. */
+typedef enum _i2c_slave_address_mode
+{
+    kI2C_Address7bit = 0x0U, /*!< 7-bit addressing mode. */
+    kI2C_RangeMatch  = 0X2U, /*!< Range address match addressing mode. */
+} i2c_slave_address_mode_t;
+
+/*! @brief I2C transfer control flag. */
+enum _i2c_master_transfer_flags
+{
+    kI2C_TransferDefaultFlag = 0x0U,       /*!< A transfer starts with a start signal, stops with a stop signal. */
+    kI2C_TransferNoStartFlag = 0x1U,       /*!< A transfer starts without a start signal, only support write only or
+                                        write+read with no start flag, do not support read only with no start flag. */
+    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< A transfer starts with a repeated start signal. */
+    kI2C_TransferNoStopFlag        = 0x4U, /*!< A transfer ends without a stop signal. */
+};
+
+/*!
+ * @brief Set of events sent to the callback for nonblocking slave transfers.
+ *
+ * These event enumerations are used for two related purposes. First, a bit mask created by OR'ing together
+ * events is passed to I2C_SlaveTransferNonBlocking() to specify which events to enable.
+ * Then, when the slave callback is invoked, it is passed the current event through its @a transfer
+ * parameter.
+ *
+ * @note These enumerations are meant to be OR'd together to form a bit mask of events.
+ */
+typedef enum _i2c_slave_transfer_event
+{
+    kI2C_SlaveAddressMatchEvent = 0x01U, /*!< Received the slave address after a start or repeated start. */
+    kI2C_SlaveTransmitEvent     = 0x02U, /*!< A callback is requested to provide data to transmit
+                                                (slave-transmitter role). */
+    kI2C_SlaveReceiveEvent = 0x04U,      /*!< A callback is requested to provide a buffer in which to place received
+                                                 data (slave-receiver role). */
+    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< A callback needs to either transmit an ACK or NACK. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kI2C_SlaveStartEvent = 0x10U, /*!< A start/repeated start was detected. */
+#endif
+    kI2C_SlaveCompletionEvent  = 0x20U, /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveGenaralcallEvent = 0x40U, /*!< Received the general call address after a start or repeated start. */
+
+    /*! A bit mask of all available events. */
+    kI2C_SlaveAllEvents = kI2C_SlaveAddressMatchEvent | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent |
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+                          kI2C_SlaveStartEvent |
+#endif
+                          kI2C_SlaveCompletionEvent | kI2C_SlaveGenaralcallEvent,
+} i2c_slave_transfer_event_t;
+
+/*! @brief Common sets of flags used by the driver. */
+enum
+{
+/*! All flags which are cleared by the driver upon starting a transfer. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag | kI2C_StartDetectFlag | kI2C_StopDetectFlag,
+    kIrqFlags   = kI2C_GlobalInterruptEnable | kI2C_StartStopDetectInterruptEnable,
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag | kI2C_StopDetectFlag,
+    kIrqFlags   = kI2C_GlobalInterruptEnable | kI2C_StopDetectInterruptEnable,
+#else
+    kClearFlags = kI2C_ArbitrationLostFlag | kI2C_IntPendingFlag,
+    kIrqFlags   = kI2C_GlobalInterruptEnable,
+#endif
+};
+
+/*! @brief I2C master user configuration. */
+typedef struct _i2c_master_config
+{
+    bool enableMaster; /*!< Enables the I2C peripheral at initialization time. */
+#if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
+    bool enableStopHold; /*!< Controls the stop hold enable. */
+#endif
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    bool enableDoubleBuffering; /*!< Controls double buffer enable; notice that
+                                     enabling the double buffer disables the clock stretch. */
+#endif
+    uint32_t baudRate_Bps;     /*!< Baud rate configuration of I2C peripheral. */
+    uint8_t glitchFilterWidth; /*!< Controls the width of the glitch. */
+} i2c_master_config_t;
+
+/*! @brief I2C slave user configuration. */
+typedef struct _i2c_slave_config
+{
+    bool enableSlave;       /*!< Enables the I2C peripheral at initialization time. */
+    bool enableGeneralCall; /*!< Enables the general call addressing mode. */
+    bool enableWakeUp;      /*!< Enables/disables waking up MCU from low-power mode. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    bool enableDoubleBuffering; /*!< Controls a double buffer enable; notice that
+                                     enabling the double buffer disables the clock stretch. */
+#endif
+    bool enableBaudRateCtl; /*!< Enables/disables independent slave baud rate on SCL in very fast I2C modes. */
+    uint16_t slaveAddress;  /*!< A slave address configuration. */
+    uint16_t upperAddress;  /*!< A maximum boundary slave address used in a range matching mode. */
+    i2c_slave_address_mode_t
+        addressingMode;          /*!< An addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint32_t sclStopHoldTime_ns; /*!< the delay from the rising edge of SCL (I2C clock) to the rising edge of SDA (I2C
+                                    data) while SCL is high (stop condition), SDA hold time and SCL start hold time
+                                    are also configured according to the SCL stop hold time. */
+} i2c_slave_config_t;
+
+/*! @brief I2C master handle typedef. */
+typedef struct _i2c_master_handle i2c_master_handle_t;
+
+/*! @brief I2C master transfer callback typedef. */
+typedef void (*i2c_master_transfer_callback_t)(I2C_Type *base,
+                                               i2c_master_handle_t *handle,
+                                               status_t status,
+                                               void *userData);
+
+/*! @brief I2C slave handle typedef. */
+typedef struct _i2c_slave_handle i2c_slave_handle_t;
+
+/*! @brief I2C master transfer structure. */
+typedef struct _i2c_master_transfer
+{
+    uint32_t flags;            /*!< A transfer flag which controls the transfer. */
+    uint8_t slaveAddress;      /*!< 7-bit slave address. */
+    i2c_direction_t direction; /*!< A transfer direction, read or write. */
+    uint32_t subaddress;       /*!< A sub address. Transferred MSB first. */
+    uint8_t subaddressSize;    /*!< A size of the command buffer. */
+    uint8_t *volatile data;    /*!< A transfer buffer. */
+    volatile size_t dataSize;  /*!< A transfer size. */
+} i2c_master_transfer_t;
+
+/*! @brief I2C master handle structure. */
+struct _i2c_master_handle
+{
+    i2c_master_transfer_t transfer;                    /*!< I2C master transfer copy. */
+    size_t transferSize;                               /*!< Total bytes to be transferred. */
+    uint8_t state;                                     /*!< A transfer state maintained during transfer. */
+    i2c_master_transfer_callback_t completionCallback; /*!< A callback function called when the transfer is finished. */
+    void *userData;                                    /*!< A callback parameter passed to the callback function. */
+};
+
+/*! @brief I2C slave transfer structure. */
+typedef struct _i2c_slave_transfer
+{
+    i2c_slave_transfer_event_t event; /*!< A reason that the callback is invoked. */
+    uint8_t *volatile data;           /*!< A transfer buffer. */
+    volatile size_t dataSize;         /*!< A transfer size. */
+    status_t completionStatus;        /*!< Success or error code describing how the transfer completed. Only applies for
+                                         #kI2C_SlaveCompletionEvent. */
+    size_t transferredCount; /*!< A number of bytes actually transferred since the start or since the last repeated
+                                start. */
+} i2c_slave_transfer_t;
+
+/*! @brief I2C slave transfer callback typedef. */
+typedef void (*i2c_slave_transfer_callback_t)(I2C_Type *base, i2c_slave_transfer_t *xfer, void *userData);
+
+/*! @brief I2C slave handle structure. */
+struct _i2c_slave_handle
+{
+    volatile bool isBusy;                   /*!< Indicates whether a transfer is busy. */
+    i2c_slave_transfer_t transfer;          /*!< I2C slave transfer copy. */
+    uint32_t eventMask;                     /*!< A mask of enabled events. */
+    i2c_slave_transfer_callback_t callback; /*!< A callback function called at the transfer event. */
+    void *userData;                         /*!< A callback parameter passed to the callback. */
+};
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /*_cplusplus. */
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
+ * and configure the I2C with master configuration.
+ *
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can be custom filled
+ * or it can be set with default values by using the I2C_MasterGetDefaultConfig().
+ * After calling this API, the master is ready to transfer.
+ * This is an example.
+ * @code
+ * i2c_master_config_t config = {
+ * .enableMaster = true,
+ * .enableStopHold = false,
+ * .highDrive = false,
+ * .baudRate_Bps = 100000,
+ * .glitchFilterWidth = 0
+ * };
+ * I2C_MasterInit(I2C0, &config, 12000000U);
+ * @endcode
+ *
+ * @param base I2C base pointer
+ * @param masterConfig A pointer to the master configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
+ */
+void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
+ * and initialize the I2C with the slave configuration.
+ *
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can partly be set
+ * with default values by I2C_SlaveGetDefaultConfig() or it can be custom filled by the user.
+ * This is an example.
+ * @code
+ * i2c_slave_config_t config = {
+ * .enableSlave = true,
+ * .enableGeneralCall = false,
+ * .addressingMode = kI2C_Address7bit,
+ * .slaveAddress = 0x1DU,
+ * .enableWakeUp = false,
+ * .enablehighDrive = false,
+ * .enableBaudRateCtl = false,
+ * .sclStopHoldTime_ns = 4000
+ * };
+ * I2C_SlaveInit(I2C0, &config, 12000000U);
+ * @endcode
+ *
+ * @param base I2C base pointer
+ * @param slaveConfig A pointer to the slave configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
+ */
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz);
+
+/*!
+ * @brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
+ * The I2C master module can't work unless the I2C_MasterInit is called.
+ * @param base I2C base pointer
+ */
+void I2C_MasterDeinit(I2C_Type *base);
+
+/*!
+ * @brief De-initializes the I2C slave peripheral. Calling this API gates the I2C clock.
+ * The I2C slave module can't work unless the I2C_SlaveInit is called to enable the clock.
+ * @param base I2C base pointer
+ */
+void I2C_SlaveDeinit(I2C_Type *base);
+
+/*!
+ * @brief Get instance number for I2C module.
+ *
+ * @param base I2C peripheral base address.
+ */
+uint32_t I2C_GetInstance(I2C_Type *base);
+
+/*!
+ * @brief  Sets the I2C master configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
+ * Use the initialized structure unchanged in the I2C_MasterConfigure() or modify
+ * the structure before calling the I2C_MasterConfigure().
+ * This is an example.
+ * @code
+ * i2c_master_config_t config;
+ * I2C_MasterGetDefaultConfig(&config);
+ * @endcode
+ * @param masterConfig A pointer to the master configuration structure.
+ */
+void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig);
+
+/*!
+ * @brief  Sets the I2C slave configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_SlaveConfigure().
+ * Modify fields of the structure before calling the I2C_SlaveConfigure().
+ * This is an example.
+ * @code
+ * i2c_slave_config_t config;
+ * I2C_SlaveGetDefaultConfig(&config);
+ * @endcode
+ * @param slaveConfig A pointer to the slave configuration structure.
+ */
+void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
+
+/*!
+ * @brief Enables or disables the I2C peripheral operation.
+ *
+ * @param base I2C base pointer
+ * @param enable Pass true to enable and false to disable the module.
+ */
+static inline void I2C_Enable(I2C_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C1 |= I2C_C1_IICEN_MASK;
+    }
+    else
+    {
+        base->C1 &= ~(uint8_t)I2C_C1_IICEN_MASK;
+    }
+}
+
+/* @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+
+/*!
+ * @brief Gets the I2C status flags.
+ *
+ * @param base I2C base pointer
+ * @return status flag, use status flag to AND #_i2c_flags to get the related status.
+ */
+uint32_t I2C_MasterGetStatusFlags(I2C_Type *base);
+
+/*!
+ * @brief Gets the I2C status flags.
+ *
+ * @param base I2C base pointer
+ * @return status flag, use status flag to AND #_i2c_flags to get the related status.
+ */
+static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
+{
+    return I2C_MasterGetStatusFlags(base);
+}
+
+/*!
+ * @brief Clears the I2C status flag state.
+ *
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag.
+ *
+ * @param base I2C base pointer
+ * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
+ *      The parameter can be any combination of the following values:
+ *          @arg kI2C_StartDetectFlag (if available)
+ *          @arg kI2C_StopDetectFlag (if available)
+ *          @arg kI2C_ArbitrationLostFlag
+ *          @arg kI2C_IntPendingFlagFlag
+ */
+static inline void I2C_MasterClearStatusFlags(I2C_Type *base, uint32_t statusMask)
+{
+/* Must clear the STARTF / STOPF bits prior to clearing IICIF */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    if ((uint32_t)kI2C_StartDetectFlag == (statusMask & (uint32_t)kI2C_StartDetectFlag))
+    {
+        /* Shift the odd-ball flags back into place. */
+        base->FLT |= (uint8_t)(statusMask >> 8U);
+    }
+#endif
+
+#ifdef I2C_HAS_STOP_DETECT
+    if ((uint32_t)kI2C_StopDetectFlag == (statusMask & (uint32_t)kI2C_StopDetectFlag))
+    {
+        /* Shift the odd-ball flags back into place. */
+        base->FLT |= (uint8_t)(statusMask >> 8U);
+    }
+#endif
+
+    base->S = (uint8_t)statusMask;
+}
+
+/*!
+ * @brief Clears the I2C status flag state.
+ *
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ *
+ * @param base I2C base pointer
+ * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
+ *      The parameter can be any combination of the following values:
+ *          @arg kI2C_StartDetectFlag (if available)
+ *          @arg kI2C_StopDetectFlag (if available)
+ *          @arg kI2C_ArbitrationLostFlag
+ *          @arg kI2C_IntPendingFlagFlag
+ */
+static inline void I2C_SlaveClearStatusFlags(I2C_Type *base, uint32_t statusMask)
+{
+    I2C_MasterClearStatusFlags(base, statusMask);
+}
+
+/* @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/*!
+ * @brief Enables I2C interrupt requests.
+ *
+ * @param base I2C base pointer
+ * @param mask interrupt source
+ *     The parameter can be combination of the following source if defined:
+ *     @arg kI2C_GlobalInterruptEnable
+ *     @arg kI2C_StopDetectInterruptEnable/kI2C_StartDetectInterruptEnable
+ *     @arg kI2C_SdaTimeoutInterruptEnable
+ */
+void I2C_EnableInterrupts(I2C_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables I2C interrupt requests.
+ *
+ * @param base I2C base pointer
+ * @param mask interrupt source
+ *     The parameter can be combination of the following source if defined:
+ *     @arg kI2C_GlobalInterruptEnable
+ *     @arg kI2C_StopDetectInterruptEnable/kI2C_StartDetectInterruptEnable
+ *     @arg kI2C_SdaTimeoutInterruptEnable
+ */
+void I2C_DisableInterrupts(I2C_Type *base, uint32_t mask);
+
+/*!
+ * @name DMA Control
+ * @{
+ */
+#if defined(FSL_FEATURE_I2C_HAS_DMA_SUPPORT) && FSL_FEATURE_I2C_HAS_DMA_SUPPORT
+/*!
+ * @brief Enables/disables the I2C DMA interrupt.
+ *
+ * @param base I2C base pointer
+ * @param enable true to enable, false to disable
+ */
+static inline void I2C_EnableDMA(I2C_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->C1 |= I2C_C1_DMAEN_MASK;
+    }
+    else
+    {
+        base->C1 &= ~(uint8_t)I2C_C1_DMAEN_MASK;
+    }
+}
+
+#endif /* FSL_FEATURE_I2C_HAS_DMA_SUPPORT */
+
+/*!
+ * @brief  Gets the I2C tx/rx data register address. This API is used to provide a transfer address
+ * for I2C DMA transfer configuration.
+ *
+ * @param base I2C base pointer
+ * @return data register address
+ */
+static inline uint32_t I2C_GetDataRegAddr(I2C_Type *base)
+{
+    return (uint32_t)(&(base->D));
+}
+
+/* @} */
+/*!
+ * @name Bus Operations
+ * @{
+ */
+
+/*!
+ * @brief Sets the I2C master transfer baud rate.
+ *
+ * @param base I2C base pointer
+ * @param baudRate_Bps the baud rate value in bps
+ * @param srcClock_Hz Source clock
+ */
+void I2C_MasterSetBaudRate(I2C_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Sends a START on the I2C bus.
+ *
+ * This function is used to initiate a new master mode transfer by sending the START signal.
+ * The slave address is sent following the I2C START signal.
+ *
+ * @param base I2C peripheral base pointer
+ * @param address 7-bit slave device address.
+ * @param direction Master transfer directions(transmit/receive).
+ * @retval kStatus_Success Successfully send the start signal.
+ * @retval kStatus_I2C_Busy Current bus is busy.
+ */
+status_t I2C_MasterStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
+
+/*!
+ * @brief Sends a STOP signal on the I2C bus.
+ *
+ * @retval kStatus_Success Successfully send the stop signal.
+ * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
+ */
+status_t I2C_MasterStop(I2C_Type *base);
+
+/*!
+ * @brief Sends a REPEATED START on the I2C bus.
+ *
+ * @param base I2C peripheral base pointer
+ * @param address 7-bit slave device address.
+ * @param direction Master transfer directions(transmit/receive).
+ * @retval kStatus_Success Successfully send the start signal.
+ * @retval kStatus_I2C_Busy Current bus is busy but not occupied by current I2C master.
+ */
+status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
+
+/*!
+ * @brief Performs a polling send transaction on the I2C bus.
+ *
+ * @param base  The I2C peripheral base pointer.
+ * @param txBuff The pointer to the data to be transferred.
+ * @param txSize The length in bytes of the data to be transferred.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+ *  to issue a stop and kI2C_TransferNoStop to not send a stop.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags);
+
+/*!
+ * @brief Performs a polling receive transaction on the I2C bus.
+ *
+ * @note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
+ * Without stopping the bus prior for the final read, the bus issues another read, resulting
+ * in garbage data being read into the data register.
+ *
+ * @param base I2C peripheral base pointer.
+ * @param rxBuff The pointer to the data to store the received data.
+ * @param rxSize The length in bytes of the data to be received.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+ *  to issue a stop and kI2C_TransferNoStop to not send a stop.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
+ */
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags);
+
+/*!
+ * @brief Performs a polling send transaction on the I2C bus.
+ *
+ * @param base  The I2C peripheral base pointer.
+ * @param txBuff The pointer to the data to be transferred.
+ * @param txSize The length in bytes of the data to be transferred.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+
+/*!
+ * @brief Performs a polling receive transaction on the I2C bus.
+ *
+ * @param base I2C peripheral base pointer.
+ * @param rxBuff The pointer to the data to store the received data.
+ * @param rxSize The length in bytes of the data to be received.
+ * @retval kStatus_Success Successfully complete data receive.
+ * @retval kStatus_I2C_Timeout Wait status flag timeout.
+ */
+status_t I2C_SlaveReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+
+/*!
+ * @brief Performs a master polling transfer on the I2C bus.
+ *
+ * @note The API does not return until the transfer succeeds or fails due
+ * to arbitration lost or receiving a NAK.
+ *
+ * @param base I2C peripheral base address.
+ * @param xfer Pointer to the transfer structure.
+ * @retval kStatus_Success Successfully complete the data transmission.
+ * @retval kStatus_I2C_Busy Previous transmission still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
+ */
+status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer);
+
+/* @} */
+
+/*!
+ * @name Transactional
+ * @{
+ */
+
+/*!
+ * @brief Initializes the I2C handle which is used in transactional functions.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure to store the transfer state.
+ * @param callback pointer to user callback function.
+ * @param userData user parameter passed to the callback function.
+ */
+void I2C_MasterTransferCreateHandle(I2C_Type *base,
+                                    i2c_master_handle_t *handle,
+                                    i2c_master_transfer_callback_t callback,
+                                    void *userData);
+
+/*!
+ * @brief Performs a master interrupt non-blocking transfer on the I2C bus.
+ *
+ * @note Calling the API returns immediately after transfer initiates. The user needs
+ * to call I2C_MasterGetTransferCount to poll the transfer status to check whether
+ * the transfer is finished. If the return status is not kStatus_I2C_Busy, the transfer
+ * is finished.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * @param xfer pointer to i2c_master_transfer_t structure.
+ * @retval kStatus_Success Successfully start the data transmission.
+ * @retval kStatus_I2C_Busy Previous transmission still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ */
+status_t I2C_MasterTransferNonBlocking(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer);
+
+/*!
+ * @brief Gets the master transfer status during a interrupt non-blocking transfer.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @retval kStatus_InvalidArgument count is Invalid.
+ * @retval kStatus_Success Successfully return the count.
+ */
+status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Aborts an interrupt non-blocking transfer early.
+ *
+ * @note This API can be called at any time when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_master_handle_t structure which stores the transfer state
+ * @retval kStatus_I2C_Timeout Timeout during polling flag.
+ * @retval kStatus_Success Successfully abort the transfer.
+ */
+status_t I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle);
+
+/*!
+ * @brief Master interrupt handler.
+ *
+ * @param base I2C base pointer.
+ * @param i2cHandle pointer to i2c_master_handle_t structure.
+ */
+void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle);
+
+/*!
+ * @brief Initializes the I2C handle which is used in transactional functions.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_slave_handle_t structure to store the transfer state.
+ * @param callback pointer to user callback function.
+ * @param userData user parameter passed to the callback function.
+ */
+void I2C_SlaveTransferCreateHandle(I2C_Type *base,
+                                   i2c_slave_handle_t *handle,
+                                   i2c_slave_transfer_callback_t callback,
+                                   void *userData);
+
+/*!
+ * @brief Starts accepting slave transfers.
+ *
+ * Call this API after calling the I2C_SlaveInit() and I2C_SlaveTransferCreateHandle() to start processing
+ * transactions driven by an I2C master. The slave monitors the I2C bus and passes events to the
+ * callback that was passed into the call to I2C_SlaveTransferCreateHandle(). The callback is always invoked
+ * from the interrupt context.
+ *
+ * The set of events received by the callback is customizable. To do so, set the @a eventMask parameter to
+ * the OR'd combination of #i2c_slave_transfer_event_t enumerators for the events you wish to receive.
+ * The kI2C_SlaveTransmitEvent and kLPI2C_SlaveReceiveEvent events are always enabled and do not need
+ * to be included in the mask. Alternatively, pass 0 to get a default set of only the transmit and
+ * receive events that are always enabled. In addition, the #kI2C_SlaveAllEvents constant is provided as
+ * a convenient way to enable all events.
+ *
+ * @param base The I2C peripheral base address.
+ * @param handle Pointer to i2c_slave_handle_t structure which stores the transfer state.
+ * @param eventMask Bit mask formed by OR'ing together #i2c_slave_transfer_event_t enumerators to specify
+ *      which events to send to the callback. Other accepted values are 0 to get a default set of
+ *      only the transmit and receive events, and #kI2C_SlaveAllEvents to enable all events.
+ *
+ * @retval kStatus_Success Slave transfers were successfully started.
+ * @retval kStatus_I2C_Busy Slave transfers have already been started on this handle.
+ */
+status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle, uint32_t eventMask);
+
+/*!
+ * @brief Aborts the slave transfer.
+ *
+ * @note This API can be called at any time to stop slave for handling the bus events.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_slave_handle_t structure which stores the transfer state.
+ */
+void I2C_SlaveTransferAbort(I2C_Type *base, i2c_slave_handle_t *handle);
+
+/*!
+ * @brief Gets the slave transfer remaining bytes during a interrupt non-blocking transfer.
+ *
+ * @param base I2C base pointer.
+ * @param handle pointer to i2c_slave_handle_t structure.
+ * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @retval kStatus_InvalidArgument count is Invalid.
+ * @retval kStatus_Success Successfully return the count.
+ */
+status_t I2C_SlaveTransferGetCount(I2C_Type *base, i2c_slave_handle_t *handle, size_t *count);
+
+/*!
+ * @brief Slave interrupt handler.
+ *
+ * @param base I2C base pointer.
+ * @param i2cHandle pointer to i2c_slave_handle_t structure which stores the transfer state
+ */
+void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle);
+
+/* @} */
+#if defined(__cplusplus)
+}
+#endif /*_cplusplus. */
+/*@}*/
+
+#endif /* _FSL_I2C_H_*/

--- a/source/WB-CAN-Firmware.c
+++ b/source/WB-CAN-Firmware.c
@@ -19,6 +19,20 @@
 #include "fsl_dspi.h"
 #include "fsl_dspi_freertos.h"
 #include "fsl_gpio.h"
+#include "fsl_i2c.h"
+#include "fsl_i2c_freertos.h"
+
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define TC_I2C_BASE     (I2C3_BASE)
+#define TC_I2C_IRQN     (I2C3_IRQn)
+#define TC_I2C_CLK_SRC  (I2C3_CLK_SRC)
+#define TC_I2C_CLK_FREQ CLOCK_GetFreq((I2C3_CLK_SRC))
+
+
+#define TC_I2C ((I2C_Type *)TC_I2C_BASE)
 
 /*******************************************************************************
  * Prototypes
@@ -26,6 +40,7 @@
 static void blinkTask(void *pv);
 static void testTask(void *pv);
 static void actuatorTask(void *pv);
+static void tcTask(void *pv);
 
 /*******************************************************************************
  * Main
@@ -41,6 +56,8 @@ int main(void) {
     /* Init FSL debug console. */
     BOARD_InitDebugConsole();
 #endif
+
+    NVIC_SetPriority(TC_I2C_IRQN, 3);
 
 
     BaseType_t error;
@@ -82,6 +99,17 @@ int main(void) {
     	    ;
     };
 
+    if ((error =  xTaskCreate(tcTask,
+    "Thermocouple Task",
+	1024,
+	NULL,
+	0,
+	NULL)) != pdPASS) {
+    	printf("Task init failed: %ld\n", error);
+    	for (;;)
+    	    ;
+    };
+
     vTaskStartScheduler();
 
     for(;;);
@@ -113,5 +141,94 @@ static void actuatorTask(void *pv){
 		GPIO_PortToggle(BOARD_INITPINS_HS_SWITCH_B_IN1_GPIO, BOARD_INITPINS_HS_SWITCH_B_IN1_GPIO_PIN_MASK);
 		vTaskDelay(pdMS_TO_TICKS(200));
 	}
+}
+
+uint8_t g_master_buff[32] = {0};
+
+static void tcTask(void *pv){
+    i2c_rtos_handle_t master_rtos_handle;
+    i2c_master_config_t masterConfig;
+    i2c_master_transfer_t masterXfer;
+    uint32_t sourceClock;
+    status_t status;
+
+
+	i2c_master_handle_t *g_m_handle;
+
+    /*
+     * masterConfig.baudRate_Bps = 100000U;
+     * masterConfig.enableStopHold = false;
+     * masterConfig.glitchFilterWidth = 0U;
+     * masterConfig.enableMaster = true;
+     */
+    I2C_MasterGetDefaultConfig(&masterConfig);
+    masterConfig.baudRate_Bps = 10000;
+    sourceClock               = TC_I2C_CLK_FREQ;
+
+    status = I2C_RTOS_Init(&master_rtos_handle, TC_I2C, &masterConfig, sourceClock);
+
+
+
+    for(;;){
+		g_m_handle = &master_rtos_handle.drv_handle;
+
+//		g_master_buff[0] = 0b00000001;
+		g_master_buff[0] = 0b00000000;
+
+		memset(&masterXfer, 0, sizeof(masterXfer));
+		masterXfer.slaveAddress   = 0b1100111;
+		masterXfer.direction      = kI2C_Write;
+		masterXfer.subaddress     = 0;
+		masterXfer.subaddressSize = 0;
+		masterXfer.data           = g_master_buff;
+		masterXfer.dataSize       = 1;
+		masterXfer.flags          = kI2C_TransferDefaultFlag;
+
+		status = I2C_RTOS_Transfer(&master_rtos_handle, &masterXfer);
+		if (status != kStatus_Success)
+		{
+			PRINTF("I2C master: error during write transaction, %d\n", status);
+		}
+
+
+		for (uint32_t i = 0; i < 2; i++)
+		{
+			g_master_buff[i] = 0;
+		}
+
+		masterXfer.slaveAddress   = 0b1100111;
+		masterXfer.direction      = kI2C_Read;
+		masterXfer.subaddress     = 0;
+		masterXfer.subaddressSize = 0;
+		masterXfer.data           = g_master_buff;
+		masterXfer.dataSize       = 2;
+		masterXfer.flags          = kI2C_TransferDefaultFlag;
+
+		status = I2C_RTOS_Transfer(&master_rtos_handle, &masterXfer);
+
+
+		PRINTF("Received: ");
+		for (uint32_t i = 0; i < 2; i++)
+		{
+			if (i % 8 == 0)
+			{
+				PRINTF("\r\n");
+			}
+			PRINTF("0x%2x  ", g_master_buff[i]);
+		}
+		PRINTF("\r\n\r\n");
+
+		double temperature;
+		uint8_t UpperByte = g_master_buff[0];
+		uint8_t LowerByte = g_master_buff[1];
+		if ((UpperByte & 0x80) == 0x80){ //Temperature  0°C
+			temperature = (UpperByte * 16 + LowerByte / 16.0) - 4096;
+		} else //Temperature  0°C
+			temperature = (UpperByte * 16 + LowerByte / 16.0);
+
+		PRINTF("Temperature read: %.4lf\r\n", temperature);
+
+		vTaskDelay(pdMS_TO_TICKS(500));
+    }
 }
 


### PR DESCRIPTION
Added support for reading from thermocouples. Note that the wiring is wrong for the I2C line but I found a workaround as described [here](https://github.com/UBC-Rocket/WB-AV-4510-CAN/issues/15). Right now everything is in the same file as main, if it gets crowded we might want to move sensor reads out but I think it's fine for now. 